### PR TITLE
chore: Global 전역, 공통 설정 클래스 구성 및 세팅(#3)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/common/constants/SwaggerUrlConstants.java
+++ b/src/main/java/com/ject/studytrip/global/common/constants/SwaggerUrlConstants.java
@@ -1,0 +1,22 @@
+package com.ject.studytrip.global.common.constants;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SwaggerUrlConstants {
+    SWAGGER_RESOURCES_URL("/swagger-resources/**"),
+    SWAGGER_UI_URL("/swagger-ui/**"),
+    SWAGGER_API_DOCS_URL("/v3/api-docs/**"),
+    ;
+
+    private final String value;
+
+    public static String[] getSwaggerUrls() {
+        return Arrays.stream(SwaggerUrlConstants.values())
+                .map(SwaggerUrlConstants::getValue)
+                .toArray(String[]::new);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
@@ -1,0 +1,18 @@
+package com.ject.studytrip.global.common.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UrlConstants {
+    DEV_API_SERVER_URL("https://dev-api-studytrip.duckdns.org"),
+    LOCAL_API_SERVER_URL("http://localhost:8080"),
+
+    // TODO: 개발, 운영 도메인 URL 추가 작업
+    LOCAL_DOMAIN_URL("http://localhost:3000"),
+    LOCAL_SECURE_DOMAIN_URL("https://localhost:3000"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/ject/studytrip/global/common/response/StandardResponse.java
+++ b/src/main/java/com/ject/studytrip/global/common/response/StandardResponse.java
@@ -1,0 +1,14 @@
+package com.ject.studytrip.global.common.response;
+
+import com.ject.studytrip.global.exception.response.ErrorResponse;
+
+public record StandardResponse(boolean success, int status, Object data) {
+
+    public static StandardResponse success(int status, Object data) {
+        return new StandardResponse(true, status, data);
+    }
+
+    public static StandardResponse fail(int status, ErrorResponse errorResponse) {
+        return new StandardResponse(false, status, errorResponse);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/config/QuerydslConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.ject.studytrip.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/config/RedisConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.ject.studytrip.global.config;
+
+import com.ject.studytrip.global.config.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableConfigurationProperties(RedisProperties.class)
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.host(), redisProperties.port());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // 단순 Key-Value 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // 해시 Key-Value 직렬화
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/config/SchedulerConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/SchedulerConfig.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {}

--- a/src/main/java/com/ject/studytrip/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/SwaggerConfig.java
@@ -1,0 +1,77 @@
+package com.ject.studytrip.global.config;
+
+import com.ject.studytrip.global.config.properties.SwaggerProperties;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.*;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("!prod") // 로컬, 개발환경 활성화
+@EnableConfigurationProperties(SwaggerProperties.class)
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private static final String SERVER_NAME = "StudyTrip";
+    private static final String SERVER_DESCRIPTION = "StudyTrip 서버 URL 입니다.";
+    private static final String API_TITLE = "StudyTrip 서버 API 문서";
+    private static final String API_DESCRIPTION = "StudyTrip 서버 API 문서입니다.";
+    private static final String GITHUB_URL = "https://github.com/JECT-Study/JECT-4-server";
+
+    private final SwaggerProperties swaggerProperties;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .servers(swaggerServer())
+                .addSecurityItem(securityRequirement())
+                .components(authComponents())
+                .info(swaggerInfo());
+    }
+
+    private List<Server> swaggerServer() {
+        Server server =
+                new Server().url(swaggerProperties.serverUrl()).description(SERVER_DESCRIPTION);
+        return List.of(server);
+    }
+
+    private Components authComponents() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("accessToken");
+        return securityRequirement;
+    }
+
+    private Info swaggerInfo() {
+        License license = new License();
+        license.setUrl(GITHUB_URL);
+        license.setName(SERVER_NAME);
+
+        return new Info()
+                .version("v" + swaggerProperties.version())
+                .title(API_TITLE)
+                .description(API_DESCRIPTION)
+                .license(license);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/WebSecurityConfig.java
@@ -1,0 +1,88 @@
+package com.ject.studytrip.global.config;
+
+import com.ject.studytrip.global.common.constants.SwaggerUrlConstants;
+import com.ject.studytrip.global.security.CustomAccessDeniedHandler;
+import com.ject.studytrip.global.security.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Slf4j
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    private void defaultFilterChain(HttpSecurity http) throws Exception {
+        http
+                // csrf 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // http basic 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 폼 로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                // 세션 비활성화
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // cors 설정
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        defaultFilterChain(http);
+
+        // 경로 인가 설정
+        http.authorizeHttpRequests(
+                authorize ->
+                        authorize
+                                .requestMatchers(SwaggerUrlConstants.getSwaggerUrls())
+                                .permitAll() // Swagger 경로
+                                .requestMatchers("/api/sample/**")
+                                .permitAll() // 샘플 api 경로
+                                .anyRequest()
+                                .authenticated()); // 그 외 요청은 모두 인증 수행
+
+        // 예외 핸들링
+        http.exceptionHandling(
+                exception ->
+                        exception
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler));
+
+        return http.build();
+    }
+
+    // CORS 설정
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        // TODO: 환경별 CORS 허용 origin 설정 분기 처리
+        //  - dev: LOCAL_DOMAIN, LOCAL_SECURE_DOMAIN, DEV_DOMAIN 허용
+        //  - prod: PROD_DOMAIN 만 허용
+        //  - Spring Active Profile 기반 분기 필요
+        //  - 서비스 도메인, 서버 운영 환경 설정 완료 시 작업
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/config/properties/RedisProperties.java
+++ b/src/main/java/com/ject/studytrip/global/config/properties/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.ject.studytrip.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(int port, String host) {}

--- a/src/main/java/com/ject/studytrip/global/config/properties/SwaggerProperties.java
+++ b/src/main/java/com/ject/studytrip/global/config/properties/SwaggerProperties.java
@@ -1,0 +1,6 @@
+package com.ject.studytrip.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "swagger")
+public record SwaggerProperties(String version, String serverUrl) {}

--- a/src/main/java/com/ject/studytrip/global/exception/CustomException.java
+++ b/src/main/java/com/ject/studytrip/global/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.ject.studytrip.global.exception;
+
+import com.ject.studytrip.global.exception.error.CommonErrorCode;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(CommonErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/error/AuthErrorCode.java
+++ b/src/main/java/com/ject/studytrip/global/exception/error/AuthErrorCode.java
@@ -1,0 +1,29 @@
+package com.ject.studytrip.global.exception.error;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 부족합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/error/CommonErrorCode.java
+++ b/src/main/java/com/ject/studytrip/global/exception/error/CommonErrorCode.java
@@ -1,0 +1,34 @@
+package com.ject.studytrip.global.exception.error;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드 입니다."),
+    METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "요청 본문(JSON)의 값 유효성 검증에 실패했습니다."),
+    INVALID_JSON_FORMAT(
+            HttpStatus.BAD_REQUEST, "요청 본문(JSON) 형식이 잘못되어 파싱할 수 없습니다. (필드 타입 불일치, 필수 필드 누락 등)"),
+    CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "요청 파라미터 또는 경로 변수 유효성 검증에 실패했습니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 메서드 파마미터의 타입이 일치하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러. 관리자에게 문의하세요."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ject/studytrip/global/exception/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.ject.studytrip.global.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String getName();
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/ject/studytrip/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ject/studytrip/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.ject.studytrip.global.exception.handler;
+
+import com.ject.studytrip.global.common.response.StandardResponse;
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.global.exception.error.CommonErrorCode;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import com.ject.studytrip.global.exception.response.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    /** CustomException 예외 처리 */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<StandardResponse> handleCustomException(CustomException e) {
+        log.error("CustomException : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getName(), errorCode.getMessage());
+        final StandardResponse response =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** 500번대 에러 처리 */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<StandardResponse> handleException(Exception e) {
+        log.error("Internal Server Error : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getName(), errorCode.getMessage());
+        final StandardResponse response =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/handler/ValidationExceptionHandler.java
+++ b/src/main/java/com/ject/studytrip/global/exception/handler/ValidationExceptionHandler.java
@@ -1,0 +1,160 @@
+package com.ject.studytrip.global.exception.handler;
+
+import com.ject.studytrip.global.common.response.StandardResponse;
+import com.ject.studytrip.global.exception.error.CommonErrorCode;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import com.ject.studytrip.global.exception.response.ErrorResponse;
+import com.ject.studytrip.global.exception.response.FieldErrorResponse;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ValidationExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /** ResponseEntityExceptionHandler 가 기본으로 처리하는 예외를 공통으로 처리 */
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception e,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest webRequest) {
+        ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), e.getMessage());
+
+        return super.handleExceptionInternal(e, errorResponse, headers, statusCode, webRequest);
+    }
+
+    /** 요청 본문(Json) 에서 유효성 제약 조건 위반 시 발생(바인딩 실패), 주로 RequestBody, RequestPart 에서 발생 */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest webRequest) {
+        log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+
+        List<FieldErrorResponse> fieldErrors =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(
+                                fieldError ->
+                                        FieldErrorResponse.of(
+                                                fieldError.getField(),
+                                                fieldError.getDefaultMessage()))
+                        .toList();
+
+        final ErrorCode errorCode = CommonErrorCode.METHOD_ARGUMENT_NOT_VALID;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getName(), errorCode.getMessage(), fieldErrors);
+        final StandardResponse response = StandardResponse.fail(statusCode.value(), errorResponse);
+
+        return ResponseEntity.status(statusCode).body(response);
+    }
+
+    /** 요청 본문(JSON) 형식이 잘못되어 파싱할 수 없는 경우 발생 (필드 타입 불일치, 필수 필드 누락 시 발생) */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+        log.error("HttpMessageNotReadableException : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = CommonErrorCode.INVALID_JSON_FORMAT;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final StandardResponse response =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** RequestParam, PathVariable 등 메서드 파라미터에서 제약 조건을 위반해 바인딩 실패 시 발생 */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<StandardResponse> handleConstrainViolationException(
+            ConstraintViolationException e) {
+        log.error("ConstrainViolationException : {}", e.getMessage(), e);
+
+        List<FieldErrorResponse> bindingErrors =
+                e.getConstraintViolations().stream()
+                        .map(
+                                constraintViolation -> {
+                                    List<String> propertyPath =
+                                            List.of(
+                                                    constraintViolation
+                                                            .getPropertyPath()
+                                                            .toString()
+                                                            .split("\\."));
+
+                                    String path =
+                                            propertyPath.stream()
+                                                    .skip(propertyPath.size() - 1L)
+                                                    .findFirst()
+                                                    .orElse(null);
+
+                                    return FieldErrorResponse.of(
+                                            path, constraintViolation.getMessage());
+                                })
+                        .toList();
+
+        final ErrorCode errorCode = CommonErrorCode.CONSTRAINT_VIOLATION;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getName(), errorCode.getMessage(), bindingErrors);
+        final StandardResponse response =
+                StandardResponse.fail(HttpStatus.BAD_REQUEST.value(), errorResponse);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    /** PathVariable, RequestParam, RequestHeader 에서 요청한 메서드 파라미터 타입이 일치하지 않은 경우 발생 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<StandardResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final StandardResponse response =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** 지원하지 않는 HTTP method 요청 시 발생 */
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException e,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest webRequest) {
+        log.error("HttpRequestMethodNotSupportedException : {}", e.getMethod(), e);
+
+        final ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final StandardResponse response =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/response/ErrorResponse.java
+++ b/src/main/java/com/ject/studytrip/global/exception/response/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.ject.studytrip.global.exception.response;
+
+public record ErrorResponse(String error, String message, Object values) {
+
+    public static ErrorResponse of(String error, String message, Object values) {
+        return new ErrorResponse(error, message, values);
+    }
+
+    public static ErrorResponse of(String error, String message) {
+        return new ErrorResponse(error, message, null);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/exception/response/FieldErrorResponse.java
+++ b/src/main/java/com/ject/studytrip/global/exception/response/FieldErrorResponse.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.global.exception.response;
+
+public record FieldErrorResponse(String field, String reason) {
+
+    public static FieldErrorResponse of(String field, String reason) {
+        return new FieldErrorResponse(field, reason);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/ject/studytrip/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.ject.studytrip.global.security;
+
+import com.ject.studytrip.global.exception.error.AuthErrorCode;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void handle(
+            HttpServletRequest request, HttpServletResponse response, AccessDeniedException e)
+            throws IOException, ServletException {
+        log.error("AccessDeniedException : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = AuthErrorCode.ACCESS_DENIED;
+        securityResponseHandler.sendResponse(response, errorCode);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/ject/studytrip/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.ject.studytrip.global.security;
+
+import com.ject.studytrip.global.exception.error.AuthErrorCode;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException e)
+            throws IOException, ServletException {
+        log.error("AuthenticationException : {}", e.getMessage(), e);
+
+        final ErrorCode errorCode = AuthErrorCode.UNAUTHENTICATED;
+        securityResponseHandler.sendResponse(response, errorCode);
+    }
+}

--- a/src/main/java/com/ject/studytrip/global/security/SecurityResponseHandler.java
+++ b/src/main/java/com/ject/studytrip/global/security/SecurityResponseHandler.java
@@ -1,0 +1,31 @@
+package com.ject.studytrip.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ject.studytrip.global.common.response.StandardResponse;
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import com.ject.studytrip.global.exception.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityResponseHandler {
+
+    private static final String CONTENT_TYPE = "application/json;charset=UTF-8";
+
+    private final ObjectMapper objectMapper;
+
+    public void sendResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getName(), errorCode.getMessage());
+        final StandardResponse standardResponse =
+                StandardResponse.fail(errorCode.getStatus().value(), errorResponse);
+        final String json = objectMapper.writeValueAsString(standardResponse);
+
+        response.setStatus(standardResponse.status());
+        response.setContentType(CONTENT_TYPE);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/ject/studytrip/sample/SampleController.java
+++ b/src/main/java/com/ject/studytrip/sample/SampleController.java
@@ -1,0 +1,52 @@
+package com.ject.studytrip.sample;
+
+import com.ject.studytrip.global.common.response.StandardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "sample", description = "샘플 API")
+@RequestMapping("/api/sample")
+@RestController
+public class SampleController {
+
+    @Operation(summary = "sampleGet", description = "GET 샘플 API 입니다.")
+    @GetMapping()
+    public ResponseEntity<StandardResponse> sampleGet(@RequestParam Long sampleId) {
+        StandardResponse response = StandardResponse.success(HttpStatus.OK.value(), sampleId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "samplePost", description = "POST 샘플 API 입니다.")
+    @PostMapping()
+    public ResponseEntity<StandardResponse> samplePost(@RequestBody @Valid SampleRequest request) {
+        SampleResponse sampleResponse = SampleResponse.of(request.sample(), request.sampleNum());
+        StandardResponse response =
+                StandardResponse.success(HttpStatus.CREATED.value(), sampleResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "samplePut", description = "PUT 샘플 API 입니다.")
+    @PutMapping("/{sampleId}")
+    public ResponseEntity<StandardResponse> samplePut(@PathVariable Long sampleId) {
+        StandardResponse response = StandardResponse.success(HttpStatus.OK.value(), null);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "samplePatch", description = "PATCH 샘플 API 입니다.")
+    @PatchMapping("/{sampleId}")
+    public ResponseEntity<StandardResponse> samplePatch(@PathVariable Long sampleId) {
+        StandardResponse response = StandardResponse.success(HttpStatus.OK.value(), null);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "sampleDelete", description = "DELETE 샘플 API 입니다.")
+    @DeleteMapping("/{sampleId}")
+    public ResponseEntity<StandardResponse> sampleDelete(@PathVariable Long sampleId) {
+        StandardResponse response = StandardResponse.success(HttpStatus.OK.value(), sampleId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/ject/studytrip/sample/SampleRequest.java
+++ b/src/main/java/com/ject/studytrip/sample/SampleRequest.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.sample;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SampleRequest(
+        @NotEmpty(message = "sample 은 필수입니다.") String sample,
+        @Min(value = 1, message = "sampleNum 은 1 이상이여야 합니다.") int sampleNum) {}

--- a/src/main/java/com/ject/studytrip/sample/SampleResponse.java
+++ b/src/main/java/com/ject/studytrip/sample/SampleResponse.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.sample;
+
+public record SampleResponse(String sample, int sampleNum) {
+
+    public static SampleResponse of(String sample, int sampleNum) {
+        return new SampleResponse(sample, sampleNum);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
       - redis
       - security
 
+swagger:
+  version: ${SWAGGER_VERSION:1}
+  server-url: ${API_SERVER_URL:http://localhost:8080}
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ 공통 응답 및 예외 처리
- `StandardResponse` 클래스를 추가해 API 응답을 통일된 포맷으로 제공할 수 있도록 구성했습니다.
- 공통 에러코드를 `ErrorCode` 인터페이스로 추상화하고, 도메인별로 `CommonErrorCode`, `AuthErrorCode` 등을 정의해 에러 코드를 관리할 수 있도록 구성했습니다.
- 최상위 에러코드를 설계하면서 공통적으로 사용될 `CommonErrorCode` 와, 인증/인가 부분에서 사용될 `AuthErrorCode` 일부분 세팅했습니다.
- `ErrorResponse` 클래스를 추가하여 에러 응답을 전용 구조로 분리하였고, `MethodArgumentNotValidException`과 같이 바인딩 오류가 발생했을 경우에는 에러 메시지와 함께 유효성 검증에 실패한 필드 정보들을 포함해 응답할 수 있도록 설계했습니다.
- 전역 예외를 처리하는 핸들러와 유효성 검증 관련 예외를 처리하는 핸들러를 별도로 구성해 책임을 분리했습니다.(`GlobalExceptionHandler`, `ValidationExceptionHandler`)

### ✅ 전역 상수 관리
- `global.common.constants` 패키지를 만들고, 전역에서 사용할 수 있는 상수들을 클래스로 관리할 수 있도록 구성했습니다.
- `SwaggerUrlConstants` 클래스를 구성해 WebSecurity 설정에 필요한 swagger 관련 경로를 관리하고, 향후 JWT 필터에서 재사용할 수 있을 것 같습니다.
- `UrlConstants` 클래스를 구성해 로컬/개발/운영 서버의 URL과 클라이언트 도메인 URL 등을 통합적으로 관리할 수 있도록 설정했습니다.

### ✅ 설정 파일 구성
- swagger, web security, redis, query dsl, scheduler 초기 설정 파일을 추가했습니다.
- `application.yml` 파일에 `swagger.version` 정보를 추가해, swagger 버전 정보를 유연하게 관리할 수 있도록 설정했습니다.
- 운영환경(prod) 에서는 swagger 비활성화 처리해주었습니다.

### ✅ 스프링 시큐리티
- 인증 실패 시 발생하는 예외를 처리하기 위해 `CustomAuthenticationEntryPoint` 클래스를, 접근 권한이 없을 때 발생하는 예외를 처리하기 위해 `CustomAccessDeniedHandler` 클래스를 구성했습니다.
- Security 필터에서 발생하는 예외 응답을 일관된 형태로 내려주기 위해 `SecurityResponseHandler` 클래스를 추가했습니다. HttpServletResponse를 통해 JSON 형태로 표준 응답을 내려줍니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #3 

<br/>

## 🔍 참고사항(선택)
- 

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

**[swagger local test]**
<img width="1440" alt="스크린샷 2025-06-18 오후 10 54 37" src="https://github.com/user-attachments/assets/e8591bf7-9137-4ce9-833a-41091b6cc522" />


**[스프링 시큐리티 인증 예외처리]**
<img width="1440" alt="스크린샷 2025-06-18 오후 8 40 11" src="https://github.com/user-attachments/assets/9c8b01ab-ba2e-47e8-b8e2-d65e812b9318" />
