### PR TITLE
chore: develop 환경 배포 워크플로우 구성(#5)

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,0 +1,79 @@
+name: develop push Build and deploy
+
+on:
+  push:
+    branches: [ "develop" ]
+
+env:
+  DOCKERHUB_USERNAME: ject4tserver
+  DOCKERHUB_IMAGE_NAME: studytrip-server
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+
+    strategy:
+      matrix:
+        java-version: [ 17 ]
+        distribution: [ 'temurin' ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
+
+      - name: Grant Execute Permission for Gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            bootJar
+            --scan
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_KEY }}
+
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5.5.0
+        env:
+          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
+          tags: |
+            type=sha,prefix=
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+
+      - name: Deploy to EC2 Server
+        uses: appleboy/ssh-action@1.0.3
+        env:
+          DOCKERHUB_IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
+          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DOCKERHUB_IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME
+          debug: true
+          script: |
+            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            docker compose up -d
+            docker image prune -a -f

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -1,0 +1,35 @@
+name: develop Deploy
+
+on:
+  # 워크플로우를 수동으로 트리거, 수동 배포
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: "commit hash"
+        required: true
+
+env:
+  DOCKERHUB_USERNAME: ject4tserver
+  DOCKERHUB_IMAGE_NAME: studytrip-server
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+
+    steps:
+      - name: Deploy to EC2 Server
+        uses: appleboy/ssh-action@1.0.3
+        env:
+          DOCKERHUB_IMAGE_FULL_PATH: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:${{ github.event.inputs.commit_hash }}
+          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DOCKERHUB_IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME
+          debug: true
+          script: |
+            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            docker compose up -d
+            docker image prune -a -f

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 ###
-.DS_Store
+**/.DS_Store
 
 ### ENV
 *.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM amazoncorretto:17-alpine-jdk
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
+jar.enabled = false // 일반 JAR 파일 생성 비활성화
+
 tasks.named('test') {
     useJUnitPlatform()
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ Develop 배포 워크플로우 구성
- `develop_build_deploy` 워크플로우를 구성했습니다.
: `develop` 브랜치에 `push` 이벤트가 발생할 때 자동으로 실행됩니다.
: `pull request` 이벤트에서 이미 테스트를 수행하기 때문에, 배포 워크플로우에서는 테스트를 생략하고 `bootJar` 명령으로 빠르게 실행 가능한 JAR 파일만 생성하도록 설정했습니다. 배포 시에도 테스트가 필요하다고 판단되면 수정하겠습니다.
: 배포 관련 정보는 Github Environments 의 `DEV` 환경을 만들어 Secrets 으로 관리하도록 설정했습니다.

- `develop_deploy` 워크플로우를 구성했습니다.
: 이 워크플로우는 자동으로 실행되지 않고, Github Actions 에서 수동으로 실행할 수 있는 워크플로우입니다. 
: `커밋 해시값`을 필수로 입력해야하며, 입력한 커밋을 기준으로 생성된 도커 이미지를 사용해 배포를 실행합니다. 
: 빠르게 재배포가 필요하거나 특정 커밋 기준으로 돌아가야할 때 유용하게 활용할 수 있을 것 같습니다.

- 배포 시 도커 이미지를 빌드할 수 있도록 `Dockerfile` 추가했습니다.
- 일반 JAR 파일과 bootJar 파일이 같이 생성되는 것을 방지하기 위해 `build.gradle` 에 `jar.enabled=false` 설정을 적용했습니다.

### ✅ 기타
- `.gitignore` 의 `.DS_Store` 파일 경로를 수정해주었습니다.

### 

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #5 

<br/>

## 🔍 참고사항(선택)

- EC2 환경에 `docker-compose.yml`, `.env` 파일 구성해두었습니다.

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-