### PR TITLE
fix: develop 배포 워크플로우 appleboy/ssh-action 버전 정보 오타 수정(#7)

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -63,7 +63,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
 
       - name: Deploy to EC2 Server
-        uses: appleboy/ssh-action@1.0.3
+        uses: appleboy/ssh-action@v1.0.3
         env:
           DOCKERHUB_IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
           DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Deploy to EC2 Server
-        uses: appleboy/ssh-action@1.0.3
+        uses: appleboy/ssh-action@v1.0.3
         env:
           DOCKERHUB_IMAGE_FULL_PATH: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:${{ github.event.inputs.commit_hash }}
           DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ 배포 워크플로우 오타 수정
- `develop` 브랜치 배포 워크플로우의 `appleboy/ssh-action` 버전 정보에 `v` 접두사가 빠져있어 에러가 발생했고, 이를 추가해 해결했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #7 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->
<img width="1061" alt="스크린샷 2025-06-19 오후 11 36 49" src="https://github.com/user-attachments/assets/a7e36220-5d6a-4d12-ae20-7afdf2c42947" />