### PR TITLE
fix: CustomException 생성자 파라미터 타입 수정(#11)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/exception/CustomException.java
+++ b/src/main/java/com/ject/studytrip/global/exception/CustomException.java
@@ -1,6 +1,5 @@
 package com.ject.studytrip.global.exception;
 
-import com.ject.studytrip.global.exception.error.CommonErrorCode;
 import com.ject.studytrip.global.exception.error.ErrorCode;
 import lombok.Getter;
 
@@ -9,7 +8,7 @@ public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public CustomException(CommonErrorCode errorCode) {
+    public CustomException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ CustomException 생성자 파라미터 타입 수정
- `CustomException` 생성자에서 `CommonErrorCode` 타입의 파라미터 값을 받고 있어, 공통 에러코드 인터페이스 `ErrorCode` 타입으로 수정했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #11 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-