### PR TITLE
chore: 통합 테스트 응답 데이터 파싱 메서드 정의(#19)

### DIFF
--- a/src/test/java/com/ject/studytrip/BaseIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/BaseIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(classes = {StudytripApplication.class})
@@ -20,4 +21,16 @@ public abstract class BaseIntegrationTest {
 
     @Autowired protected MockMvc mockMvc;
     @Autowired protected ObjectMapper objectMapper;
+
+    /**
+     * 응답 본문(JSON)을 지정한 클래스 타입으로 변환하는 메서드, 테스트 응답 결과를 객체로 파싱해 내용 검증에 활용할 수 있음
+     *
+     * @param result MockMvc 응답 결과
+     * @param clazz 변환할 클래스 타입
+     * @return 파싱된 응답 객체
+     */
+    protected <T> T parseResponse(ResultActions result, Class<T> clazz) throws Exception {
+        String content = result.andReturn().getResponse().getContentAsString();
+        return objectMapper.readValue(content, clazz);
+    }
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ 통합 테스트 응답 데이터 파싱 메서드 정의
- 통합 테스트에서 응답 데이터를 쉽게 추출하고 검증할 수 있도록, 응답 데이터 파싱을 담당하는 `parseResponse()` 메서드를 정의했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #19 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-