### PR TITLE
refactor: MemberCategory 변환 및 Member 도메인 검증 로직 분리(#25)

### DIFF
--- a/src/main/java/com/ject/studytrip/auth/application/facade/AuthFacade.java
+++ b/src/main/java/com/ject/studytrip/auth/application/facade/AuthFacade.java
@@ -6,8 +6,8 @@ import com.ject.studytrip.auth.presentation.dto.request.KakaoLoginRequest;
 import com.ject.studytrip.auth.presentation.dto.request.KakaoSignupRequest;
 import com.ject.studytrip.auth.presentation.dto.response.TokenResponse;
 import com.ject.studytrip.member.application.service.MemberService;
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ject/studytrip/member/application/service/MemberService.java
+++ b/src/main/java/com/ject/studytrip/member/application/service/MemberService.java
@@ -1,12 +1,11 @@
 package com.ject.studytrip.member.application.service;
 
-import static io.jsonwebtoken.lang.Strings.hasText;
-
 import com.ject.studytrip.global.exception.CustomException;
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.MemberCategory;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
 import com.ject.studytrip.member.domain.error.MemberErrorCode;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.MemberCategory;
+import com.ject.studytrip.member.domain.model.SocialProvider;
+import com.ject.studytrip.member.domain.policy.MemberPolicy;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import com.ject.studytrip.member.factory.MemberFactory;
 import lombok.RequiredArgsConstructor;
@@ -36,33 +35,15 @@ public class MemberService {
     @Transactional
     public Member createMemberFromKakao(
             String kakaoId, String email, String profileImage, String category, String nickname) {
-        validateNewMember(kakaoId);
-        MemberCategory parsedCategory = parseCategory(category);
-        validateMemberNickname(nickname);
+        boolean exists =
+                memberRepository.existsBySocialProviderAndSocialId(SocialProvider.KAKAO, kakaoId);
+        MemberPolicy.validateNickname(nickname);
+        MemberPolicy.validateNewMember(exists);
+
+        MemberCategory memberCategory = MemberCategory.from(category);
         Member member =
-                MemberFactory.fromKakao(kakaoId, email, profileImage, nickname, parsedCategory);
+                MemberFactory.fromKakao(kakaoId, email, profileImage, nickname, memberCategory);
+
         return memberRepository.save(member);
-    }
-
-    private MemberCategory parseCategory(String category) {
-        try {
-            return MemberCategory.valueOf(category);
-        } catch (IllegalArgumentException | NullPointerException e) {
-            throw new CustomException(MemberErrorCode.MEMBER_CATEGORY_REQUIRED);
-        }
-    }
-
-    private void validateNewMember(String socialId) {
-        if (memberRepository
-                .findBySocialProviderAndSocialId(SocialProvider.KAKAO, socialId)
-                .isPresent()) {
-            throw new CustomException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
-        }
-    }
-
-    private void validateMemberNickname(String nickname) {
-        if (!hasText(nickname)) {
-            throw new CustomException(MemberErrorCode.MEMBER_NICKNAME_REQUIRED);
-        }
     }
 }

--- a/src/main/java/com/ject/studytrip/member/domain/entity/MemberCategory.java
+++ b/src/main/java/com/ject/studytrip/member/domain/entity/MemberCategory.java
@@ -1,8 +1,0 @@
-package com.ject.studytrip.member.domain.entity;
-
-public enum MemberCategory {
-    STUDENT,
-    WORKER,
-    FREELANCER,
-    JOBSEEKER
-}

--- a/src/main/java/com/ject/studytrip/member/domain/error/MemberErrorCode.java
+++ b/src/main/java/com/ject/studytrip/member/domain/error/MemberErrorCode.java
@@ -11,7 +11,7 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."),
     MEMBER_NEED_SIGNUP(HttpStatus.CONFLICT, "회원가입이 필요한 사용자입니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
-    ;
+    INVALID_MEMBER_CATEGORY(HttpStatus.BAD_REQUEST, "유효하지 않은 멤버 카테고리입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ject/studytrip/member/domain/model/Member.java
+++ b/src/main/java/com/ject/studytrip/member/domain/model/Member.java
@@ -1,4 +1,4 @@
-package com.ject.studytrip.member.domain.entity;
+package com.ject.studytrip.member.domain.model;
 
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/ject/studytrip/member/domain/model/MemberCategory.java
+++ b/src/main/java/com/ject/studytrip/member/domain/model/MemberCategory.java
@@ -1,0 +1,26 @@
+package com.ject.studytrip.member.domain.model;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.error.MemberErrorCode;
+
+public enum MemberCategory {
+    STUDENT,
+    WORKER,
+    FREELANCER,
+    JOBSEEKER,
+    ;
+
+    public static MemberCategory from(String category) {
+        if (!hasText(category)) {
+            throw new CustomException(MemberErrorCode.MEMBER_CATEGORY_REQUIRED);
+        }
+
+        try {
+            return MemberCategory.valueOf(category);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MemberErrorCode.INVALID_MEMBER_CATEGORY);
+        }
+    }
+}

--- a/src/main/java/com/ject/studytrip/member/domain/model/MemberRole.java
+++ b/src/main/java/com/ject/studytrip/member/domain/model/MemberRole.java
@@ -1,4 +1,4 @@
-package com.ject.studytrip.member.domain.entity;
+package com.ject.studytrip.member.domain.model;
 
 public enum MemberRole {
     ROLE_USER,

--- a/src/main/java/com/ject/studytrip/member/domain/model/SocialProvider.java
+++ b/src/main/java/com/ject/studytrip/member/domain/model/SocialProvider.java
@@ -1,4 +1,4 @@
-package com.ject.studytrip.member.domain.entity;
+package com.ject.studytrip.member.domain.model;
 
 public enum SocialProvider {
     KAKAO,

--- a/src/main/java/com/ject/studytrip/member/domain/policy/MemberPolicy.java
+++ b/src/main/java/com/ject/studytrip/member/domain/policy/MemberPolicy.java
@@ -1,0 +1,24 @@
+package com.ject.studytrip.member.domain.policy;
+
+import static io.jsonwebtoken.lang.Strings.hasText;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.error.MemberErrorCode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberPolicy {
+
+    public static void validateNickname(String nickname) {
+        if (!hasText(nickname)) {
+            throw new CustomException(MemberErrorCode.MEMBER_NICKNAME_REQUIRED);
+        }
+    }
+
+    public static void validateNewMember(boolean exists) {
+        if (exists) {
+            throw new CustomException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/com/ject/studytrip/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/ject/studytrip/member/domain/repository/MemberRepository.java
@@ -1,12 +1,14 @@
 package com.ject.studytrip.member.domain.repository;
 
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import java.util.Optional;
 
 public interface MemberRepository {
     Optional<Member> findBySocialProviderAndSocialId(
             SocialProvider socialProvider, String socialId);
+
+    boolean existsBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
 
     Optional<Member> findById(Long id);
 

--- a/src/main/java/com/ject/studytrip/member/factory/MemberFactory.java
+++ b/src/main/java/com/ject/studytrip/member/factory/MemberFactory.java
@@ -1,9 +1,9 @@
 package com.ject.studytrip.member.factory;
 
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.MemberCategory;
-import com.ject.studytrip.member.domain.entity.MemberRole;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.MemberCategory;
+import com.ject.studytrip.member.domain.model.MemberRole;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ject/studytrip/member/infra/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/member/infra/jpa/MemberJpaRepository.java
@@ -1,11 +1,13 @@
 package com.ject.studytrip.member.infra.jpa;
 
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialProviderAndSocialId(
             SocialProvider socialProvider, String socialId);
+
+    boolean existsBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
 }

--- a/src/main/java/com/ject/studytrip/member/infra/jpa/MemberRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/member/infra/jpa/MemberRepositoryAdapter.java
@@ -1,7 +1,7 @@
 package com.ject.studytrip.member.infra.jpa;
 
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,12 @@ public class MemberRepositoryAdapter implements MemberRepository {
     public Optional<Member> findBySocialProviderAndSocialId(
             SocialProvider socialProvider, String socialId) {
         return memberJpaRepository.findBySocialProviderAndSocialId(socialProvider, socialId);
+    }
+
+    @Override
+    public boolean existsBySocialProviderAndSocialId(
+            SocialProvider socialProvider, String socialId) {
+        return memberJpaRepository.existsBySocialProviderAndSocialId(socialProvider, socialId);
     }
 
     @Override

--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
@@ -1,7 +1,7 @@
 package com.ject.studytrip.trip.application.facade;
 
 import com.ject.studytrip.member.application.service.MemberService;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.stamp.application.dto.StampInfo;
 import com.ject.studytrip.stamp.application.service.StampService;
 import com.ject.studytrip.stamp.domain.model.Stamp;

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
@@ -1,7 +1,7 @@
 package com.ject.studytrip.trip.application.service;
 
 import com.ject.studytrip.global.exception.CustomException;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.error.TripErrorCode;
 import com.ject.studytrip.trip.domain.factory.TripFactory;
 import com.ject.studytrip.trip.domain.model.Trip;

--- a/src/main/java/com/ject/studytrip/trip/domain/factory/TripFactory.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/factory/TripFactory.java
@@ -1,6 +1,6 @@
 package com.ject.studytrip.trip.domain.factory;
 
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.time.LocalDate;

--- a/src/main/java/com/ject/studytrip/trip/domain/model/Trip.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/Trip.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.trip.domain.model;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/com/ject/studytrip/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/ject/studytrip/member/application/service/MemberServiceTest.java
@@ -5,9 +5,9 @@ import static org.mockito.BDDMockito.*;
 
 import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.global.exception.CustomException;
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
 import com.ject.studytrip.member.domain.error.MemberErrorCode;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import java.util.Optional;
@@ -109,8 +109,10 @@ class MemberServiceTest extends BaseUnitTest {
         @DisplayName("이미 존재하는 멤버라면 예외가 발생한다.")
         void shouldThrowExceptionWhenMemberAlreadyExists() {
             // given
-            given(memberRepository.findBySocialProviderAndSocialId(SocialProvider.KAKAO, KAKAO_ID))
-                    .willReturn(Optional.of(member));
+            given(
+                            memberRepository.existsBySocialProviderAndSocialId(
+                                    SocialProvider.KAKAO, KAKAO_ID))
+                    .willReturn(true);
 
             // when & then
             assertThatThrownBy(
@@ -127,13 +129,13 @@ class MemberServiceTest extends BaseUnitTest {
     class CreateMemberFromKakao {
 
         @Test
-        @DisplayName("카테고리가 유효하지 않으면 예외가 발생한다.")
-        void shouldThrowExceptionWhenCategoryIsInvalid() {
+        @DisplayName("카테고리가 비어 있으면 예외가 발생한다.")
+        void shouldThrowExceptionWhenCategoryIsBlank() {
             // when & then
             assertThatThrownBy(
                             () ->
                                     memberService.createMemberFromKakao(
-                                            KAKAO_ID, EMAIL, PROFILE_IMAGE, "INVALID", NICKNAME))
+                                            KAKAO_ID, EMAIL, PROFILE_IMAGE, " ", NICKNAME))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MemberErrorCode.MEMBER_CATEGORY_REQUIRED.getMessage());
         }
@@ -154,8 +156,10 @@ class MemberServiceTest extends BaseUnitTest {
         @DisplayName("모든 정보가 유효하면 Member를 생성하고 반환한다.")
         void shouldCreateMemberWhenAllDataIsValid() {
             // given
-            given(memberRepository.findBySocialProviderAndSocialId(SocialProvider.KAKAO, KAKAO_ID))
-                    .willReturn(Optional.empty());
+            given(
+                            memberRepository.existsBySocialProviderAndSocialId(
+                                    SocialProvider.KAKAO, KAKAO_ID))
+                    .willReturn(false);
             given(memberRepository.save(any(Member.class))).willReturn(member);
 
             // when
@@ -171,8 +175,10 @@ class MemberServiceTest extends BaseUnitTest {
         @DisplayName("프로필 이미지가 없어도 Member를 생성하고 반환한다.")
         void shouldCreateMemberWhenProfileImageIsNull() {
             // given
-            given(memberRepository.findBySocialProviderAndSocialId(SocialProvider.KAKAO, KAKAO_ID))
-                    .willReturn(Optional.empty());
+            given(
+                            memberRepository.existsBySocialProviderAndSocialId(
+                                    SocialProvider.KAKAO, KAKAO_ID))
+                    .willReturn(false);
             given(memberRepository.save(any(Member.class))).willReturn(memberWithoutProfileImage);
 
             // when

--- a/src/test/java/com/ject/studytrip/member/fixture/MemberFixture.java
+++ b/src/test/java/com/ject/studytrip/member/fixture/MemberFixture.java
@@ -1,9 +1,9 @@
 package com.ject.studytrip.member.fixture;
 
-import com.ject.studytrip.member.domain.entity.Member;
-import com.ject.studytrip.member.domain.entity.MemberCategory;
-import com.ject.studytrip.member.domain.entity.MemberRole;
-import com.ject.studytrip.member.domain.entity.SocialProvider;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.MemberCategory;
+import com.ject.studytrip.member.domain.model.MemberRole;
+import com.ject.studytrip.member.domain.model.SocialProvider;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class MemberFixture {

--- a/src/test/java/com/ject/studytrip/member/helper/MemberTestHelper.java
+++ b/src/test/java/com/ject/studytrip/member/helper/MemberTestHelper.java
@@ -1,6 +1,6 @@
 package com.ject.studytrip.member.helper;
 
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.*;
 
 import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.global.exception.CustomException;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.factory.StampFactory;

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.*;
 
 import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.global.exception.CustomException;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.error.TripErrorCode;
 import com.ject.studytrip.trip.domain.model.Trip;

--- a/src/test/java/com/ject/studytrip/trip/fixture/TripFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/TripFixture.java
@@ -1,6 +1,6 @@
 package com.ject.studytrip.trip.fixture;
 
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.factory.TripFactory;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;

--- a/src/test/java/com/ject/studytrip/trip/helper/TripTestHelper.java
+++ b/src/test/java/com/ject/studytrip/trip/helper/TripTestHelper.java
@@ -1,6 +1,6 @@
 package com.ject.studytrip.trip.helper;
 
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import com.ject.studytrip.trip.domain.repository.TripRepository;

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
@@ -10,7 +10,7 @@ import com.ject.studytrip.auth.domain.error.AuthErrorCode;
 import com.ject.studytrip.auth.helper.TokenTestHelper;
 import com.ject.studytrip.global.common.response.StandardResponse;
 import com.ject.studytrip.global.exception.error.CommonErrorCode;
-import com.ject.studytrip.member.domain.entity.Member;
+import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.helper.MemberTestHelper;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.fixture.CreateStampRequestFixture;


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

- `MemberService` 내부 로직을 정리하고, 역할 분리를 통해 응집도 향상
- `MemberCategory`에 문자열 입력을 안전하게 변환하는 `from` 정적 메서드 구현
- `MemberPolicy`를 도입하여 신규 멤버 유효성 검증 로직 분리
- `MemberErrorCode`에 **INVALID_MEMBER_CATEGORY** 메시지 추가
- 패키지 구조 변경: `member.domain.entity` → `member.domain.model`
- `MemberServiceTest`에 **shouldThrowExceptionWhenCategoryIsInvalid** 메서드 삭제
- `MemberServiceTest`에 **shouldThrowExceptionWhenCategoryIsBlank** 메서드 추가
<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #25 

<br/>

## 🔍 참고사항(선택)

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-