### PR TITLE
feat: 미션, 학습기록, 데일리 미션, 데일리 목표 도메인 엔티티 생성(#24)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/domain/model/DailyMission.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/model/DailyMission.java
@@ -1,0 +1,30 @@
+package com.ject.studytrip.mission.domain.model;
+
+import com.ject.studytrip.global.common.entity.BaseTimeEntity;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class DailyMission extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_goal_id", nullable = false)
+    private DailyGoal dailyGoal;
+
+    public static DailyMission of(Mission mission, DailyGoal dailyGoal) {
+        return DailyMission.builder().mission(mission).dailyGoal(dailyGoal).build();
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/model/Mission.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/model/Mission.java
@@ -1,0 +1,38 @@
+package com.ject.studytrip.mission.domain.model;
+
+import com.ject.studytrip.global.common.entity.BaseTimeEntity;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class Mission extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stamp_id", nullable = false)
+    private Stamp stamp;
+
+    @Column(nullable = false)
+    private String name;
+
+    private int missionOrder;
+
+    private boolean completed;
+
+    public static Mission of(Stamp stamp, String name, int missionOrder) {
+        return Mission.builder()
+                .stamp(stamp)
+                .name(name)
+                .missionOrder(missionOrder)
+                .completed(false)
+                .build();
+    }
+}

--- a/src/main/java/com/ject/studytrip/studylog/domain/model/StudyLog.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/model/StudyLog.java
@@ -1,0 +1,32 @@
+package com.ject.studytrip.studylog.domain.model;
+
+import com.ject.studytrip.global.common.entity.BaseTimeEntity;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class StudyLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_goal_id", nullable = false)
+    private DailyGoal dailyGoal;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    public static StudyLog of(DailyGoal dailyGoal, String title, String content) {
+        return StudyLog.builder().dailyGoal(dailyGoal).title(title).content(content).build();
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
@@ -1,0 +1,27 @@
+package com.ject.studytrip.trip.domain.model;
+
+import com.ject.studytrip.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class DailyGoal extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    private boolean completed;
+
+    public static DailyGoal of(Trip trip) {
+        return DailyGoal.builder().trip(trip).completed(false).build();
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 작업 내용
- `Mission`, `DailyGoal`, `DailyMission`, `StudyLog` 도메인 엔티티 생성
- 모든 엔티티는 `BaseTimeEntity`를 상속하여 생성/수정 시간 자동 관리
- 연관 관계는 모두 **@ManyToOne(fetch = LAZY)**로 구성
- 도메인 생성은 `of` 정적 팩토리 메서드로 처리

### ✅ 특이사항
- **dailygoal**, **dailymission**, **dailystudylog**로 패키지를 분리해 도메인 명확성은 확보했지만, 구조가 지나치게 세분화된 측면이 있습니다.
- `DailyGoal`과 `DailyMission`은 비즈니스적으로 밀접한 관계를 가지므로, **daily 패키지**로 통합하거나 **trip, mission 패키지**로 역할별 분리도 고려할 수 있습니다.
- `DailyStudyLog`는 확장 가능성을 고려해, 클래스명을 `StudyLog`로 변경해도 좋을 것 같아요.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #24 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-