### PR TITLE
feat: 스탬프 기능 구현(#23)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/application/dto/MissionInfo.java
+++ b/src/main/java/com/ject/studytrip/mission/application/dto/MissionInfo.java
@@ -1,0 +1,24 @@
+package com.ject.studytrip.mission.application.dto;
+
+import com.ject.studytrip.global.util.DateUtil;
+import com.ject.studytrip.mission.domain.model.Mission;
+
+public record MissionInfo(
+        Long missionId,
+        String missionName,
+        int missionOrder,
+        boolean completed,
+        String createdAt,
+        String updatedAt,
+        String deletedAt) {
+    public static MissionInfo from(Mission mission) {
+        return new MissionInfo(
+                mission.getId(),
+                mission.getName(),
+                mission.getMissionOrder(),
+                mission.isCompleted(),
+                DateUtil.formatDateTime(mission.getCreatedAt()),
+                DateUtil.formatDateTime(mission.getUpdatedAt()),
+                DateUtil.formatDateTime(mission.getDeletedAt()));
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
@@ -1,0 +1,20 @@
+package com.ject.studytrip.mission.application.service;
+
+import com.ject.studytrip.mission.application.dto.MissionInfo;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.repository.MissionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+    private final MissionRepository missionRepository;
+
+    public List<MissionInfo> getMissionsByStamp(Long stampId) {
+        List<Mission> missions = missionRepository.findAllByStampIdOrderByMissionOrder(stampId);
+
+        return missions.stream().map(MissionInfo::from).toList();
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/MissionRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/MissionRepository.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.mission.domain.repository;
+
+import com.ject.studytrip.mission.domain.model.Mission;
+import java.util.List;
+
+public interface MissionRepository {
+    List<Mission> findAllByStampIdOrderByMissionOrder(Long stampId);
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionJpaRepository.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.Mission;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionJpaRepository extends JpaRepository<Mission, Long> {
+    List<Mission> findAllByStampIdOrderByMissionOrder(Long stampId);
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.repository.MissionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionRepositoryAdapter implements MissionRepository {
+    private final MissionJpaRepository missionJpaRepository;
+
+    @Override
+    public List<Mission> findAllByStampIdOrderByMissionOrder(Long stampId) {
+        return missionJpaRepository.findAllByStampIdOrderByMissionOrder(stampId);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/presentation/dto/response/LoadMissionInfoResponse.java
+++ b/src/main/java/com/ject/studytrip/mission/presentation/dto/response/LoadMissionInfoResponse.java
@@ -1,0 +1,15 @@
+package com.ject.studytrip.mission.presentation.dto.response;
+
+import com.ject.studytrip.mission.application.dto.MissionInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoadMissionInfoResponse(
+        @Schema(description = "미션 ID") Long missionId,
+        @Schema(description = "미션 이름") String missionName,
+        @Schema(description = "미션 순서") int missionOrder,
+        @Schema(description = "미션 완료여부") boolean completed) {
+    public static LoadMissionInfoResponse of(MissionInfo info) {
+        return new LoadMissionInfoResponse(
+                info.missionId(), info.missionName(), info.missionOrder(), info.completed());
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/application/dto/StampDetail.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/dto/StampDetail.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.stamp.application.dto;
+
+import com.ject.studytrip.mission.application.dto.MissionInfo;
+import java.util.List;
+
+public record StampDetail(StampInfo stampInfo, List<MissionInfo> missionInfos) {
+    public static StampDetail from(StampInfo stampInfo, List<MissionInfo> missionInfos) {
+        return new StampDetail(stampInfo, missionInfos);
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
@@ -1,0 +1,77 @@
+package com.ject.studytrip.stamp.application.facade;
+
+import com.ject.studytrip.mission.application.dto.MissionInfo;
+import com.ject.studytrip.mission.application.service.MissionService;
+import com.ject.studytrip.stamp.application.dto.StampDetail;
+import com.ject.studytrip.stamp.application.dto.StampInfo;
+import com.ject.studytrip.stamp.application.service.StampService;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
+import com.ject.studytrip.trip.application.service.TripService;
+import com.ject.studytrip.trip.domain.model.Trip;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StampFacade {
+    private final TripService tripService;
+    private final StampService stampService;
+    private final MissionService missionService;
+
+    @Transactional
+    public StampInfo createStamp(Long memberId, Long tripId, CreateStampRequest request) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+        Stamp stamp = stampService.createStamp(trip, request);
+
+        tripService.increaseTotalStamps(trip);
+
+        return StampInfo.from(stamp);
+    }
+
+    @Transactional
+    public void updateStampNameAndDeadline(
+            Long memberId, Long tripId, Long stampId, UpdateStampNameAndDeadlineRequest request) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+        Stamp stamp = stampService.getValidStamp(trip.getId(), stampId);
+
+        stampService.updateStampNameAndDeadline(trip, stamp, request);
+    }
+
+    @Transactional
+    public void updateStampOrders(Long memberId, Long tripId, UpdateStampOrderRequest request) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+
+        stampService.updateStampsOrders(trip, request);
+    }
+
+    @Transactional
+    public void deleteStamp(Long memberId, Long tripId, Long stampId) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+        Stamp stamp = stampService.getValidStamp(trip.getId(), stampId);
+
+        stampService.deleteStamp(trip.getId(), trip.getCategory(), stamp);
+        tripService.decreaseTotalStamps(trip);
+
+        // TODO : 추후 삭제로직 업데이트 (연쇄 삭제 처리)
+    }
+
+    public List<StampInfo> getStampsByTrip(Long memberId, Long tripId) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+        List<Stamp> stamps = stampService.getStampsByTripId(trip.getId());
+
+        return stamps.stream().map(StampInfo::from).toList();
+    }
+
+    public StampDetail getStamp(Long memberId, Long tripId, Long stampId) {
+        Trip trip = tripService.getValidTrip(memberId, tripId);
+        Stamp stamp = stampService.getValidStamp(trip.getId(), stampId);
+        List<MissionInfo> missionInfos = missionService.getMissionsByStamp(stamp.getId());
+
+        return StampDetail.from(StampInfo.from(stamp), missionInfos);
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
@@ -1,13 +1,22 @@
 package com.ject.studytrip.stamp.application.service;
 
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.factory.StampFactory;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.policy.StampPolicy;
+import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
 import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +25,23 @@ import org.springframework.stereotype.Service;
 public class StampService {
 
     private final StampRepository stampRepository;
+    private final StampQueryRepository stampQueryRepository;
+
+    public Stamp createStamp(Trip trip, CreateStampRequest request) {
+        Stamp newStamp =
+                StampFactory.create(trip, request.name(), request.order(), request.deadline());
+
+        StampPolicy.validateStampDeadline(trip.getEndDate(), List.of(newStamp));
+
+        List<Stamp> existingStamps =
+                stampRepository.findAllByTripIdAndDeletedAtIsNull(trip.getId());
+        List<Stamp> combinedStamps = new ArrayList<>(existingStamps);
+        combinedStamps.add(newStamp);
+
+        StampPolicy.validateStampOrders(trip.getCategory(), combinedStamps);
+
+        return stampRepository.save(newStamp);
+    }
 
     public void createStamps(Trip trip, List<CreateStampRequest> requests) {
         List<Stamp> stamps =
@@ -35,6 +61,38 @@ public class StampService {
         stampRepository.saveAll(stamps);
     }
 
+    public void updateStampNameAndDeadline(
+            Trip trip, Stamp stamp, UpdateStampNameAndDeadlineRequest request) {
+        stamp.update(request.name(), request.deadline());
+
+        StampPolicy.validateStampDeadline(trip.getEndDate(), List.of(stamp));
+    }
+
+    public void updateStampsOrders(Trip trip, UpdateStampOrderRequest request) {
+        // 배치 조회 (ID 목록 기준으로 조회하지만 순서는 보장되지 않음)
+        List<Stamp> stamps = stampRepository.findAllByIdIn(request.orderedStampIds());
+
+        StampPolicy.validateUpdateStampOrders(
+                trip.getCategory(), request.orderedStampIds(), stamps);
+        stamps.forEach(
+                stamp -> {
+                    StampPolicy.validateStampBelongsToTrip(trip.getId(), stamp);
+                    StampPolicy.validateNotDeleted(stamp);
+                });
+
+        // 조회된 스탬프 ID 를 기준으로 매핑
+        Map<Long, Stamp> stampMap =
+                stamps.stream().collect(Collectors.toMap(Stamp::getId, Function.identity()));
+
+        // 요청에서 전달된 ID 순서를 기준으로 스탬프 리스트 재정렬
+        List<Stamp> orderedStamps = request.orderedStampIds().stream().map(stampMap::get).toList();
+
+        int newOrder = 1;
+        for (Stamp stamp : orderedStamps) {
+            stamp.updateStampOrder(newOrder++);
+        }
+    }
+
     public void updateStampsOrderByTripCategoryChange(Long tripId, TripCategory newCategory) {
         List<Stamp> stamps = stampRepository.findAllByTripIdOrderByDeadlineAsc(tripId);
 
@@ -49,7 +107,36 @@ public class StampService {
         }
     }
 
+    public void deleteStamp(Long tripId, TripCategory tripCategory, Stamp stamp) {
+        stamp.updateDeletedAt();
+
+        if (tripCategory == TripCategory.COURSE) {
+            shiftStampOrdersAfterDeleted(tripId, stamp.getStampOrder());
+        }
+    }
+
     public List<Stamp> getStampsByTripId(Long tripId) {
-        return stampRepository.findAllByTripId(tripId);
+        return stampRepository.findAllByTripIdAndDeletedAtIsNull(tripId);
+    }
+
+    public Stamp getValidStamp(Long tripId, Long stampId) {
+        Stamp stamp =
+                stampRepository
+                        .findById(stampId)
+                        .orElseThrow(() -> new CustomException(StampErrorCode.STAMP_NOT_FOUND));
+
+        StampPolicy.validateStampBelongsToTrip(tripId, stamp);
+        StampPolicy.validateNotDeleted(stamp);
+
+        return stamp;
+    }
+
+    private void shiftStampOrdersAfterDeleted(Long tripId, int deletedStampOrder) {
+        List<Stamp> affectedStamps =
+                stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedStampOrder);
+
+        for (Stamp stamp : affectedStamps) {
+            stamp.updateStampOrder(stamp.getStampOrder() - 1);
+        }
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/domain/error/StampErrorCode.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/error/StampErrorCode.java
@@ -14,6 +14,15 @@ public enum StampErrorCode implements ErrorCode {
     INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP(
             HttpStatus.BAD_REQUEST, "코스형 여행의 스탬프 순서의 범위는 최소 1 이상 또는 최대 총 스탬프 개수여야 합니다."),
     DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP(HttpStatus.BAD_REQUEST, "코스형 여행의 스탬프 순서에 중복된 값이 존재합니다."),
+    STAMP_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 스탬프입니다."),
+    CANNOT_UPDATE_ORDER_FOR_EXPLORATION_TRIP(HttpStatus.BAD_REQUEST, "탐험형 여행의 스탬프 순서는 변경할 수 없습니다."),
+    INVALID_STAMP_ID_IN_REQUEST(HttpStatus.BAD_REQUEST, "존재하지 않는 스탬프 ID가 포함되어 있습니다. "),
+
+    // 403
+    STAMP_NOT_BELONG_TO_TRIP(HttpStatus.FORBIDDEN, "해당 스탬프는 요청한 여행에 속하지 않습니다."),
+
+    // 404
+    STAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 스탬프가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ject/studytrip/stamp/domain/model/Stamp.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/model/Stamp.java
@@ -1,9 +1,13 @@
 package com.ject.studytrip.stamp.domain.model;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
 import com.ject.studytrip.trip.domain.model.Trip;
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.*;
 
 @Entity
@@ -41,7 +45,16 @@ public class Stamp extends BaseTimeEntity {
                 .build();
     }
 
+    public void update(String name, LocalDate deadline) {
+        if (hasText(name)) this.name = name;
+        if (Objects.nonNull(deadline)) this.deadline = deadline;
+    }
+
     public void updateStampOrder(int newOrder) {
         this.stampOrder = newOrder;
+    }
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/domain/policy/StampPolicy.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/policy/StampPolicy.java
@@ -13,6 +13,16 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StampPolicy {
+    public static void validateStampBelongsToTrip(Long tripId, Stamp stamp) {
+        if (!stamp.getTrip().getId().equals(tripId))
+            throw new CustomException(StampErrorCode.STAMP_NOT_BELONG_TO_TRIP);
+    }
+
+    public static void validateNotDeleted(Stamp stamp) {
+        if (stamp.getDeletedAt() != null)
+            throw new CustomException(StampErrorCode.STAMP_ALREADY_DELETED);
+    }
+
     public static void validateStampDeadline(LocalDate tripEndDate, List<Stamp> stamps) {
         if (tripEndDate == null || stamps.isEmpty()) return;
 
@@ -50,5 +60,14 @@ public class StampPolicy {
                     throw new CustomException(StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP);
             }
         }
+    }
+
+    public static void validateUpdateStampOrders(
+            TripCategory tripCategory, List<Long> orderedStampIds, List<Stamp> savedStamps) {
+        if (tripCategory == TripCategory.EXPLORE && !orderedStampIds.isEmpty())
+            throw new CustomException(StampErrorCode.CANNOT_UPDATE_ORDER_FOR_EXPLORATION_TRIP);
+
+        if (orderedStampIds.size() != savedStamps.size())
+            throw new CustomException(StampErrorCode.INVALID_STAMP_ID_IN_REQUEST);
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.stamp.domain.repository;
+
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import java.util.List;
+
+public interface StampQueryRepository {
+    List<Stamp> findStampsToShiftAfterOrder(Long tripId, int deletedOrder);
+}

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampRepository.java
@@ -2,11 +2,18 @@ package com.ject.studytrip.stamp.domain.repository;
 
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import java.util.List;
+import java.util.Optional;
 
 public interface StampRepository {
+    Stamp save(Stamp stamp);
+
     List<Stamp> saveAll(List<Stamp> stamps);
 
-    List<Stamp> findAllByTripId(Long tripId);
+    Optional<Stamp> findById(Long stampId);
+
+    List<Stamp> findAllByIdIn(List<Long> ids);
+
+    List<Stamp> findAllByTripIdAndDeletedAtIsNull(Long tripId);
 
     List<Stamp> findAllByTripIdOrderByDeadlineAsc(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampJpaRepository.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StampJpaRepository extends JpaRepository<Stamp, Long> {
-    List<Stamp> findAllByTripId(Long tripId);
+    List<Stamp> findAllByIdIn(List<Long> ids);
+
+    List<Stamp> findAllByTripIdAndDeletedAtIsNull(Long tripId);
 
     List<Stamp> findAllByTripIdOrderByDeadlineAsc(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampQueryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.ject.studytrip.stamp.infra.jpa;
+
+import com.ject.studytrip.stamp.domain.model.QStamp;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StampQueryRepositoryAdapter implements StampQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QStamp stamp = QStamp.stamp;
+
+    @Override
+    public List<Stamp> findStampsToShiftAfterOrder(Long tripId, int deletedOrder) {
+        return queryFactory
+                .selectFrom(stamp)
+                .where(
+                        stamp.trip.id.eq(tripId),
+                        stamp.stampOrder.gt(deletedOrder),
+                        stamp.deletedAt.isNull())
+                .orderBy(stamp.stampOrder.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.stamp.infra.jpa;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,13 +13,28 @@ public class StampRepositoryAdapter implements StampRepository {
     private final StampJpaRepository stampJpaRepository;
 
     @Override
+    public Stamp save(Stamp stamp) {
+        return stampJpaRepository.save(stamp);
+    }
+
+    @Override
     public List<Stamp> saveAll(List<Stamp> stamps) {
         return stampJpaRepository.saveAll(stamps);
     }
 
     @Override
-    public List<Stamp> findAllByTripId(Long tripId) {
-        return stampJpaRepository.findAllByTripId(tripId);
+    public Optional<Stamp> findById(Long stampId) {
+        return stampJpaRepository.findById(stampId);
+    }
+
+    @Override
+    public List<Stamp> findAllByIdIn(List<Long> ids) {
+        return stampJpaRepository.findAllByIdIn(ids);
+    }
+
+    @Override
+    public List<Stamp> findAllByTripIdAndDeletedAtIsNull(Long tripId) {
+        return stampJpaRepository.findAllByTripIdAndDeletedAtIsNull(tripId);
     }
 
     @Override

--- a/src/main/java/com/ject/studytrip/stamp/presentation/controller/StampController.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/controller/StampController.java
@@ -1,0 +1,110 @@
+package com.ject.studytrip.stamp.presentation.controller;
+
+import com.ject.studytrip.global.common.response.StandardResponse;
+import com.ject.studytrip.stamp.application.dto.StampDetail;
+import com.ject.studytrip.stamp.application.dto.StampInfo;
+import com.ject.studytrip.stamp.application.facade.StampFacade;
+import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
+import com.ject.studytrip.stamp.presentation.dto.response.CreateStampResponse;
+import com.ject.studytrip.stamp.presentation.dto.response.LoadStampDetailResponse;
+import com.ject.studytrip.stamp.presentation.dto.response.LoadStampInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Stamp", description = "스탬프 API")
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class StampController {
+    private final StampFacade stampFacade;
+
+    @Operation(summary = "스탬프 등록", description = "특정 여행에 새로운 스탬프를 등록합니다.")
+    @PostMapping("/api/trips/{tripId}/stamps")
+    public ResponseEntity<StandardResponse> createStamp(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @RequestBody @Valid CreateStampRequest request) {
+        StampInfo result = stampFacade.createStamp(Long.valueOf(memberId), tripId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        StandardResponse.success(
+                                HttpStatus.CREATED.value(), CreateStampResponse.of(result)));
+    }
+
+    @Operation(summary = "스탬프 이름, 마감일 수정", description = "특정 스탬프의 이름과 마감일을 수정합니다.")
+    @PatchMapping("/api/trips/{tripId}/stamps/{stampId}")
+    public ResponseEntity<StandardResponse> updateStamp(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "스탬프 ID는 필수 요청 파라미터입니다.") Long stampId,
+            @RequestBody @Valid UpdateStampNameAndDeadlineRequest request) {
+        stampFacade.updateStampNameAndDeadline(Long.valueOf(memberId), tripId, stampId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @Operation(summary = "스탬프 순서 변경", description = "스탬프 순서를 변경합니다. 스탬프 ID 목록을 최종 순서대로 요청합니다.")
+    @PutMapping("/api/trips/{tripId}/stamps/orders")
+    public ResponseEntity<StandardResponse> updateStampOrders(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @RequestBody @Valid UpdateStampOrderRequest request) {
+        stampFacade.updateStampOrders(Long.valueOf(memberId), tripId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @Operation(summary = "스탬프 삭제", description = "특정 스탬프를 삭제합니다.")
+    @DeleteMapping("/api/trips/{tripId}/stamps/{stampId}")
+    public ResponseEntity<StandardResponse> deleteStamp(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "스탬프 ID는 필수 요청 파라미터입니다.") Long stampId) {
+        stampFacade.deleteStamp(Long.valueOf(memberId), tripId, stampId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @Operation(summary = "스탬프 목록 조회", description = "특정 여행의 스탬프 목록을 조회합니다.")
+    @GetMapping("/api/trips/{tripId}/stamps")
+    public ResponseEntity<StandardResponse> loadStampsByTrip(
+            @AuthenticationPrincipal String memberId, @PathVariable Long tripId) {
+        List<StampInfo> result = stampFacade.getStampsByTrip(Long.valueOf(memberId), tripId);
+        List<LoadStampInfoResponse> response =
+                result.stream().map(LoadStampInfoResponse::of).toList();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    @Operation(summary = "스탬프 상세 조회", description = "특정 여행의 특정 스탬프 상세 정보를 조회합니다.")
+    @GetMapping("api/trips/{tripId}/stamps/{stampId}")
+    public ResponseEntity<StandardResponse> loadStamp(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "스탬프 ID는 필수 요청 파라미터입니다.") Long stampId) {
+        StampDetail result = stampFacade.getStamp(Long.valueOf(memberId), tripId, stampId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        StandardResponse.success(
+                                HttpStatus.OK.value(),
+                                LoadStampDetailResponse.of(
+                                        result.stampInfo(), result.missionInfos())));
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/UpdateStampNameAndDeadlineRequest.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/UpdateStampNameAndDeadlineRequest.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.stamp.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.FutureOrPresent;
+import java.time.LocalDate;
+
+public record UpdateStampNameAndDeadlineRequest(
+        @Schema(description = "수정할 스탬프 이름") String name,
+        @Schema(description = "수정할 스탬프 마감일")
+                @FutureOrPresent(message = "스탬프 마감일은 현재 날짜보다 과거일 수 없습니다.")
+                LocalDate deadline) {}

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/UpdateStampOrderRequest.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/UpdateStampOrderRequest.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.stamp.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record UpdateStampOrderRequest(
+        @Schema(description = "변경된 순서를 반영한 스탬프 ID 목록 (앞에서부터 순서대로 정렬)")
+                List<Long> orderedStampIds) {}

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/CreateStampResponse.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/CreateStampResponse.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.stamp.presentation.dto.response;
+
+import com.ject.studytrip.stamp.application.dto.StampInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateStampResponse(@Schema(description = "스탬프 ID") Long stampId) {
+    public static CreateStampResponse of(StampInfo info) {
+        return new CreateStampResponse(info.stampId());
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/LoadStampDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/LoadStampDetailResponse.java
@@ -1,20 +1,25 @@
 package com.ject.studytrip.stamp.presentation.dto.response;
 
+import com.ject.studytrip.mission.application.dto.MissionInfo;
+import com.ject.studytrip.mission.presentation.dto.response.LoadMissionInfoResponse;
 import com.ject.studytrip.stamp.application.dto.StampInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public record LoadStampDetailResponse(
         @Schema(description = "스탬프 ID") Long stampId,
         @Schema(description = "스탬프 이름") String stampName,
         @Schema(description = "스탬프 순서") int stampOrder,
         @Schema(description = "스탬프 마감일") String stampDeadline,
-        @Schema(description = "스탬프 완료 여부") boolean completed) {
-    public static LoadStampDetailResponse of(StampInfo stampInfo) {
+        @Schema(description = "스탬프 완료 여부") boolean completed,
+        @Schema(description = "미션 목록") List<LoadMissionInfoResponse> missions) {
+    public static LoadStampDetailResponse of(StampInfo stampInfo, List<MissionInfo> missionInfos) {
         return new LoadStampDetailResponse(
                 stampInfo.stampId(),
                 stampInfo.stampName(),
                 stampInfo.stampOrder(),
                 stampInfo.deadline(),
-                stampInfo.completed());
+                stampInfo.completed(),
+                missionInfos.stream().map(LoadMissionInfoResponse::of).toList());
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/LoadStampInfoResponse.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/response/LoadStampInfoResponse.java
@@ -1,0 +1,20 @@
+package com.ject.studytrip.stamp.presentation.dto.response;
+
+import com.ject.studytrip.stamp.application.dto.StampInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoadStampInfoResponse(
+        @Schema(description = "스탬프 ID") Long stampId,
+        @Schema(description = "스탬프 이름") String stampName,
+        @Schema(description = "스탬프 순서") int stampOrder,
+        @Schema(description = "스탬프 마감일") String stampDeadline,
+        @Schema(description = "스탬프 완료 여부") boolean completed) {
+    public static LoadStampInfoResponse of(StampInfo info) {
+        return new LoadStampInfoResponse(
+                info.stampId(),
+                info.stampName(),
+                info.stampOrder(),
+                info.deadline(),
+                info.completed());
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
@@ -47,15 +47,25 @@ public class TripService {
 
         TripPolicy.validateOwner(memberId, trip);
         TripPolicy.validateEndDateIsNotBeforeStartDate(trip.getStartDate(), request.endDate());
-        TripPolicy.validateDeleted(trip);
+        TripPolicy.validateNotDeleted(trip);
 
         trip.update(request.name(), request.memo(), category, request.endDate());
+    }
+
+    public void increaseTotalStamps(Trip trip) {
+        trip.increaseTotalStamps();
+    }
+
+    public void decreaseTotalStamps(Trip trip) {
+        trip.decreaseTotalStamps();
     }
 
     public void deleteTrip(Long memberId, Trip trip) {
         TripPolicy.validateOwner(memberId, trip);
 
         trip.updateDeletedAt();
+
+        // TODO : 삭제는 로직을 더 구상해본 후 추후 리팩토링
     }
 
     public Trip getTrip(Long tripId) {
@@ -64,7 +74,19 @@ public class TripService {
                         .findById(tripId)
                         .orElseThrow(() -> new CustomException(TripErrorCode.TRIP_NOT_FOUND));
 
-        TripPolicy.validateDeleted(trip);
+        TripPolicy.validateNotDeleted(trip);
+
+        return trip;
+    }
+
+    public Trip getValidTrip(Long memberId, Long tripId) {
+        Trip trip =
+                tripRepository
+                        .findById(tripId)
+                        .orElseThrow(() -> new CustomException(TripErrorCode.TRIP_NOT_FOUND));
+
+        TripPolicy.validateOwner(memberId, trip);
+        TripPolicy.validateNotDeleted(trip);
 
         return trip;
     }

--- a/src/main/java/com/ject/studytrip/trip/domain/model/Trip.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/Trip.java
@@ -86,6 +86,14 @@ public class Trip extends BaseTimeEntity {
     //        if (Objects.nonNull(deadline)) this.deadline = deadline;
     //    }
 
+    public void increaseTotalStamps() {
+        this.totalStamps += 1;
+    }
+
+    public void decreaseTotalStamps() {
+        this.totalStamps -= 1;
+    }
+
     public void updateIsComplete(boolean completed) {
         this.completed = completed;
     }

--- a/src/main/java/com/ject/studytrip/trip/domain/policy/TripPolicy.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/policy/TripPolicy.java
@@ -33,7 +33,7 @@ public class TripPolicy {
             throw new CustomException(TripErrorCode.TRIP_STAMP_REQUIRED);
     }
 
-    public static void validateDeleted(Trip trip) {
+    public static void validateNotDeleted(Trip trip) {
         if (trip.getDeletedAt() != null)
             throw new CustomException(TripErrorCode.TRIP_ALREADY_DELETED);
     }

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadTripDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadTripDetailResponse.java
@@ -1,7 +1,7 @@
 package com.ject.studytrip.trip.presentation.dto.response;
 
 import com.ject.studytrip.stamp.application.dto.StampInfo;
-import com.ject.studytrip.stamp.presentation.dto.response.LoadStampDetailResponse;
+import com.ject.studytrip.stamp.presentation.dto.response.LoadStampInfoResponse;
 import com.ject.studytrip.trip.application.dto.TripInfo;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,7 +19,7 @@ public record LoadTripDetailResponse(
         @Schema(description = "완료된 총 스탬프 수") int completedStamps,
         @Schema(description = "진행률") Integer progress,
         @Schema(description = "여행 완료 여부") boolean completed,
-        @Schema(description = "여행에 속한 스탬프 목록") List<LoadStampDetailResponse> stamps) {
+        @Schema(description = "여행에 속한 스탬프 목록") List<LoadStampInfoResponse> stamps) {
     public static LoadTripDetailResponse of(TripInfo tripInfo, List<StampInfo> stampInfos) {
         return new LoadTripDetailResponse(
                 tripInfo.tripId(),
@@ -33,6 +33,6 @@ public record LoadTripDetailResponse(
                 tripInfo.completedStamps(),
                 tripInfo.progress(),
                 tripInfo.completed(),
-                stampInfos.stream().map(LoadStampDetailResponse::of).toList());
+                stampInfos.stream().map(LoadStampInfoResponse::of).toList());
     }
 }

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
@@ -12,19 +12,21 @@ import com.ject.studytrip.global.exception.CustomException;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
-import com.ject.studytrip.stamp.domain.factory.StampFactory;
 import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
 import com.ject.studytrip.stamp.fixture.CreateStampRequestFixture;
+import com.ject.studytrip.stamp.fixture.StampFixture;
+import com.ject.studytrip.stamp.fixture.UpdateStampRequestFixture;
 import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import com.ject.studytrip.trip.fixture.TripFixture;
 import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,175 +36,441 @@ import org.mockito.Mock;
 
 @DisplayName("StampService 단위 테스트")
 public class StampServiceTest extends BaseUnitTest {
-    private static final String STAMP_NAME = "STAMP NAME";
-    private static final LocalDate STAMP_DEAD_LINE = LocalDate.now().plusDays(7);
+    private static final LocalDate PAST_DATE = LocalDate.now().minusDays(1);
 
     @InjectMocks private StampService stampService;
     @Mock private StampRepository stampRepository;
+    @Mock private StampQueryRepository stampQueryRepository;
 
+    private Member member;
     private Trip courseTrip;
     private Trip exploreTrip;
+    private Stamp courseStamp1;
+    private Stamp courseStamp2;
 
     @BeforeEach
     void setup() {
-        Member member = MemberFixture.createMemberFromKakao();
-        courseTrip = TripFixture.createTrip(member, TripCategory.COURSE);
-        exploreTrip = TripFixture.createTrip(member, TripCategory.EXPLORE);
+        member = MemberFixture.createMemberFromKakao();
+        courseTrip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
+        exploreTrip = TripFixture.createTripWithId(2L, member, TripCategory.EXPLORE);
+        courseStamp1 = StampFixture.createStampWithId(1L, courseTrip, 1);
+        courseStamp2 = StampFixture.createStampWithId(2L, courseTrip, 2);
     }
 
     @Nested
     @DisplayName("스탬프를 생성한다")
     class CreateStamp {
+        private final CreateStampRequestFixture fixture = new CreateStampRequestFixture();
 
-        @Test
-        @DisplayName("코스형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
-        void shouldCreateStampsForCourseTrip() {
-            // given
-            List<CreateStampRequest> requests = List.of(new CreateStampRequestFixture().build());
+        @Nested
+        @DisplayName("단일 스탬프 생성")
+        class CreateSingleStamp {
 
-            // when
-            stampService.createStamps(courseTrip, requests);
+            @Test
+            @DisplayName("유효한 요청으로 스탬프를 생성하면 스탬프가 저장되고 반환된다")
+            void shouldCreateValidStamp() {
+                // given
+                CreateStampRequest request = fixture.build();
 
-            // then
-            verify(stampRepository).saveAll(anyList());
+                Stamp saved =
+                        Stamp.of(courseTrip, request.name(), request.order(), request.deadline());
+                given(stampRepository.save(any())).willReturn(saved);
+
+                // when
+                Stamp stamp = stampService.createStamp(courseTrip, request);
+
+                // then
+                verify(stampRepository).save(any());
+                assertThat(stamp.getName()).isEqualTo(saved.getName());
+                assertThat(stamp.getStampOrder()).isEqualTo(saved.getStampOrder());
+                assertThat(stamp.getDeadline()).isEqualTo(saved.getDeadline());
+            }
+
+            @Test
+            @DisplayName("스탬프의 마감일이 과거라면 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineCannotBeInPast() {
+                // given
+                CreateStampRequest request = fixture.withDeadline(PAST_DATE).build();
+
+                // when & given
+                assertThatThrownBy(() -> stampService.createStamp(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.STAMP_DEADLINE_CANNOT_BE_IN_PAST.getMessage());
+            }
+
+            @Test
+            @DisplayName("스탬프의 마감일이 여행 종료일보다 이후라면 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineExceedsTripEndDate() {
+                // given
+                CreateStampRequest request =
+                        fixture.withDeadline(courseTrip.getEndDate().plusDays(1)).build();
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamp(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.STAMP_DEADLINE_EXCEEDS_TRIP_END_DATE.getMessage());
+            }
+
+            @Test
+            @DisplayName("탐험형 여행에 순서가 지정된 스탬프를 등록하면 예외가 발생한다")
+            void shouldThrowExceptionWhenOrderSpecifiedForExploreTrip() {
+                // given
+                CreateStampRequest request = fixture.withStampOrder(1).build();
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamp(exploreTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP
+                                        .getMessage());
+            }
+
+            @Test
+            @DisplayName("코스형 여행에 순서가 유효 범위를 벗어난 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenOrderOutOfRange() {
+                // given
+                CreateStampRequest request = fixture.withStampOrder(1000).build();
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamp(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP
+                                        .getMessage());
+            }
+
+            @Test
+            @DisplayName("코스형 여행에 중복된 순서의 스탬프를 등록하면 예외가 발생한다")
+            void shouldThrowExceptionWhenDuplicateOrderForCourseTrip() {
+                // given
+                CreateStampRequest request = fixture.withStampOrder(1).build();
+                given(stampRepository.findAllByTripIdAndDeletedAtIsNull(courseTrip.getId()))
+                        .willReturn(List.of(courseStamp1));
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamp(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP.getMessage());
+            }
         }
 
-        @Test
-        @DisplayName("탐험형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
-        void shouldCreateStampsForExploreTrip() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(new CreateStampRequestFixture().withStampOrder(0).build());
+        @Nested
+        @DisplayName("여러개 스탬프 생성")
+        class CreateStamps {
+            @Test
+            @DisplayName("코스형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
+            void shouldCreateStampsForCourseTrip() {
+                // given
+                List<CreateStampRequest> requests = List.of(fixture.build());
 
-            // when
-            stampService.createStamps(exploreTrip, requests);
+                // when
+                stampService.createStamps(courseTrip, requests);
 
-            // then
-            verify(stampRepository).saveAll(anyList());
-        }
+                // then
+                verify(stampRepository).saveAll(anyList());
+            }
 
-        @Test
-        @DisplayName("스탬프의 마감일이 과거라면 예외가 발생한다")
-        void shouldThrowExceptionWhenStampDeadlineCannotBeInPast() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(
-                            new CreateStampRequestFixture()
-                                    .withDeadline(LocalDate.now().minusDays(1))
-                                    .build());
+            @Test
+            @DisplayName("탐험형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
+            void shouldCreateStampsForExploreTrip() {
+                // given
+                List<CreateStampRequest> requests = List.of(fixture.withStampOrder(0).build());
 
-            // when & then
-            assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(StampErrorCode.STAMP_DEADLINE_CANNOT_BE_IN_PAST.getMessage());
-        }
+                // when
+                stampService.createStamps(exploreTrip, requests);
 
-        @Test
-        @DisplayName("스탬프의 마감일이 여행 종료일보다 이후일 경우 예외가 발생한다")
-        void shouldThrowExceptionWhenStampDeadlineIsAfterTripEndDate() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(
-                            new CreateStampRequestFixture()
-                                    .withDeadline(courseTrip.getEndDate().plusDays(1))
-                                    .build());
+                // then
+                verify(stampRepository).saveAll(anyList());
+            }
 
-            // when & then
-            assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(StampErrorCode.STAMP_DEADLINE_EXCEEDS_TRIP_END_DATE.getMessage());
-        }
+            @Test
+            @DisplayName("스탬프의 마감일이 과거라면 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineCannotBeInPast() {
+                // given
+                List<CreateStampRequest> requests =
+                        List.of(fixture.withDeadline(PAST_DATE).build());
 
-        @Test
-        @DisplayName("탐험형 여행에서 순서가 1 이상이면 예외가 발생한다")
-        void shouldThrowExceptionWhenOrderExistsInExploreTrip() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(new CreateStampRequestFixture().withStampOrder(1).build());
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.STAMP_DEADLINE_CANNOT_BE_IN_PAST.getMessage());
+            }
 
-            // when & then
-            assertThatThrownBy(() -> stampService.createStamps(exploreTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP.getMessage());
-        }
+            @Test
+            @DisplayName("스탬프의 마감일이 여행 종료일보다 이후일 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineExceedsTripEndDate() {
+                // given
+                List<CreateStampRequest> requests =
+                        List.of(fixture.withDeadline(courseTrip.getEndDate().plusDays(1)).build());
 
-        @Test
-        @DisplayName("코스형 여행에서 순서가 1 미만 또는 총 개수 초과라면 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderIsOutOfRangeForCourseTrip() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(new CreateStampRequestFixture().withStampOrder(2).build());
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.STAMP_DEADLINE_EXCEEDS_TRIP_END_DATE.getMessage());
+            }
 
-            // when & then
-            assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP.getMessage());
-        }
+            @Test
+            @DisplayName("탐험형 여행에서 순서가 1 이상이면 예외가 발생한다")
+            void shouldThrowExceptionWhenOrderExistsInExploreTrip() {
+                // given
+                List<CreateStampRequest> requests = List.of(fixture.withStampOrder(1).build());
 
-        @Test
-        @DisplayName("코스형 여행에서 순서가 중복되면 예외가 발생한다")
-        void shouldThrowExceptionWhenDuplicateOrderInCourseTrip() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(
-                            new CreateStampRequestFixture().withStampOrder(1).build(),
-                            new CreateStampRequestFixture().withStampOrder(1).build());
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamps(exploreTrip, requests))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP
+                                        .getMessage());
+            }
 
-            // when & then
-            assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP.getMessage());
+            @Test
+            @DisplayName("코스형 여행에서 순서가 1 미만 또는 총 개수 초과라면 예외가 발생한다")
+            void shouldThrowExceptionWhenStampOrderIsOutOfRangeForCourseTrip() {
+                // given
+                List<CreateStampRequest> requests = List.of(fixture.withStampOrder(2).build());
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP
+                                        .getMessage());
+            }
+
+            @Test
+            @DisplayName("코스형 여행에서 순서가 중복되면 예외가 발생한다")
+            void shouldThrowExceptionWhenDuplicateOrderInCourseTrip() {
+                // given
+                List<CreateStampRequest> requests =
+                        List.of(
+                                fixture.withStampOrder(1).build(),
+                                fixture.withStampOrder(1).build());
+
+                // when & then
+                assertThatThrownBy(() -> stampService.createStamps(courseTrip, requests))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP.getMessage());
+            }
         }
     }
 
     @Nested
     @DisplayName("스탬프를 수정한다")
     class UpdateStamp {
+        private final UpdateStampRequestFixture fixture = new UpdateStampRequestFixture();
+
+        @Nested
+        @DisplayName("스탬프 이름 또는 마감일 수정")
+        class UpdateStampNameOrDeadline {
+
+            @Test
+            @DisplayName("유효한 정보로 스탬프의 이름 또는 마감일을 수정하면 스탬프가 업데이트된다")
+            void shouldUpdateStampNameOrDeadline() {
+                // given
+                UpdateStampNameAndDeadlineRequest request = fixture.buildUpdateNameAndDeadline();
+
+                // when
+                stampService.updateStampNameAndDeadline(courseTrip, courseStamp1, request);
+
+                // then
+                assertThat(courseStamp1.getName()).isEqualTo(request.name());
+                assertThat(courseStamp1.getDeadline()).isEqualTo(request.deadline());
+            }
+
+            @Test
+            @DisplayName("스탬프의 마감일이 과거라면 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineCannotBeInPast() {
+                // given
+                UpdateStampNameAndDeadlineRequest request =
+                        fixture.withDeadline(PAST_DATE).buildUpdateNameAndDeadline();
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        stampService.updateStampNameAndDeadline(
+                                                courseTrip, courseStamp1, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.STAMP_DEADLINE_CANNOT_BE_IN_PAST.getMessage());
+            }
+
+            @Test
+            @DisplayName("스탬프의 마감일이 여행 종료일보다 이후일 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineExceedsTripEndDate() {
+                // given
+                UpdateStampNameAndDeadlineRequest request =
+                        fixture.withDeadline(courseTrip.getEndDate().plusDays(1))
+                                .buildUpdateNameAndDeadline();
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        stampService.updateStampNameAndDeadline(
+                                                courseTrip, courseStamp1, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.STAMP_DEADLINE_EXCEEDS_TRIP_END_DATE.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("스탬프 순서 수정")
+        class UpdateStampOrders {
+
+            @Test
+            @DisplayName("코스형 여행에서 클라이언트가 전달한 스탬프 ID 리스트 순서에 따라 스탬프의 순서를 수정한다")
+            void shouldUpdateStampOrderForCourseTrip() {
+                // given
+                UpdateStampOrderRequest request =
+                        fixture.withOrderedStampIds(List.of(2L, 1L)).buildUpdateOrders();
+
+                given(stampRepository.findAllByIdIn(request.orderedStampIds()))
+                        .willReturn(List.of(courseStamp1, courseStamp2));
+
+                // when
+                stampService.updateStampsOrders(courseTrip, request);
+
+                // then
+                assertThat(courseStamp2.getStampOrder()).isEqualTo(1);
+                assertThat(courseStamp1.getStampOrder()).isEqualTo(2);
+            }
+
+            @Test
+            @DisplayName("탐험형 여행의 스탬프 순서를 수정하면 예외가 발생한다")
+            void shouldThrowExceptionWhenTripIsExplorationType() {
+                // given
+                UpdateStampOrderRequest request = fixture.buildUpdateOrders();
+
+                // when & then
+                assertThatThrownBy(() -> stampService.updateStampsOrders(exploreTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                StampErrorCode.CANNOT_UPDATE_ORDER_FOR_EXPLORATION_TRIP
+                                        .getMessage());
+            }
+
+            @Test
+            @DisplayName("유효하지 않는 스탬프 ID일 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenStampNotFoundById() {
+                // given
+                UpdateStampOrderRequest request =
+                        fixture.withOrderedStampIds(List.of(1000L, 1001L)).buildUpdateOrders();
+
+                // when & then
+                assertThatThrownBy(() -> stampService.updateStampsOrders(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.INVALID_STAMP_ID_IN_REQUEST.getMessage());
+            }
+
+            @Test
+            @DisplayName("여행에 속한 스탬프가 아닐 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDoesNotBelongToTrip() {
+                // given
+                UpdateStampOrderRequest request = fixture.buildUpdateOrders();
+
+                Trip newTrip = TripFixture.createTripWithId(3L, member, TripCategory.COURSE);
+                given(stampRepository.findAllByIdIn(request.orderedStampIds()))
+                        .willReturn(List.of(courseStamp1, courseStamp2));
+
+                // when & then
+                assertThatThrownBy(() -> stampService.updateStampsOrders(newTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.STAMP_NOT_BELONG_TO_TRIP.getMessage());
+            }
+
+            @Test
+            @DisplayName("삭제된 스탬프일 경우 예외가 발생한다")
+            void shouldThrowExceptionWhenStampAlreadyDeleted() {
+                // given
+                UpdateStampOrderRequest request = fixture.buildUpdateOrders();
+
+                courseStamp1.updateDeletedAt();
+                given(stampRepository.findAllByIdIn(request.orderedStampIds()))
+                        .willReturn(List.of(courseStamp1, courseStamp2));
+
+                // when & then
+                assertThatThrownBy(() -> stampService.updateStampsOrders(courseTrip, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(StampErrorCode.STAMP_ALREADY_DELETED.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("여행 카테고리에 변경사항에 따른 스탬프 순서 수정")
+        class UpdateStampOrdersForUpdateTripCategory {
+
+            @Test
+            @DisplayName("여행의 카테고리가 탐험형으로 수정되면 소속된 모든 스탬프의 순서를 0으로 수정한다")
+            void shouldSetAllStampOrdersToZeroWhenCategoryChangesToExplore() {
+                // given
+                given(stampRepository.findAllByTripIdOrderByDeadlineAsc(courseTrip.getId()))
+                        .willReturn(List.of(courseStamp1, courseStamp2));
+
+                // when
+                stampService.updateStampsOrderByTripCategoryChange(
+                        courseTrip.getId(), TripCategory.EXPLORE);
+
+                // then
+                assertThat(courseStamp1.getStampOrder()).isEqualTo(0);
+                assertThat(courseStamp2.getStampOrder()).isEqualTo(0);
+            }
+
+            @Test
+            @DisplayName("여행의 카테고리가 코스형으로 수정되면 소속된 모든 스탬프의 순서를 마감일이 이른 순으로 1부터 순차적으로 순서를 수정한다")
+            void shouldSetSequentialStampOrdersWhenCategoryChangesToCourse() {
+                // given
+                courseStamp1.updateStampOrder(0);
+                courseStamp2.updateStampOrder(0);
+
+                given(stampRepository.findAllByTripIdOrderByDeadlineAsc(exploreTrip.getId()))
+                        .willReturn(List.of(courseStamp1, courseStamp2));
+
+                // when
+                stampService.updateStampsOrderByTripCategoryChange(
+                        exploreTrip.getId(), TripCategory.COURSE);
+
+                // then
+                assertThat(courseStamp1.getStampOrder()).isEqualTo(1);
+                assertThat(courseStamp2.getStampOrder()).isEqualTo(2);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프를 삭제한다")
+    class DeleteStamp {
 
         @Test
-        @DisplayName("여행의 카테고리가 탐험형으로 수정되면 소속된 모든 스탬프의 순서를 0으로 수정한다")
-        void shouldSetAllStampOrdersToZeroWhenCategoryChangesToExplore() {
+        @DisplayName("코스형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정하고, 삭제된 스탬프 이후 순서들을 하나씩 앞당긴다")
+        void shouldDeleteCourseTripStamp() {
             // given
-            Stamp stamp = spy(StampFactory.create(courseTrip, STAMP_NAME, 1, STAMP_DEAD_LINE));
-            List<Stamp> stamps = List.of(stamp);
-
-            given(stampRepository.findAllByTripIdOrderByDeadlineAsc(courseTrip.getId()))
-                    .willReturn(stamps);
+            given(
+                            stampQueryRepository.findStampsToShiftAfterOrder(
+                                    courseTrip.getId(), courseStamp1.getStampOrder()))
+                    .willReturn(List.of(courseStamp2));
 
             // when
-            stampService.updateStampsOrderByTripCategoryChange(
-                    courseTrip.getId(), TripCategory.EXPLORE);
+            stampService.deleteStamp(courseTrip.getId(), courseTrip.getCategory(), courseStamp1);
 
             // then
-            assertThat(stamp.getStampOrder()).isEqualTo(0);
+            assertThat(courseStamp1.getDeletedAt()).isNotNull();
+            assertThat(courseStamp2.getStampOrder()).isEqualTo(1);
         }
 
         @Test
-        @DisplayName("여행의 카테고리가 코스형으로 수정되면 소속된 모든 스탬프의 순서를 마감일이 이른 순으로 1부터 순차적으로 순서를 수정한다")
-        void shouldSetSequentialStampOrdersWhenCategoryChangesToCourse() {
+        @DisplayName("탐험형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정한다")
+        void shouldDeleteExploreTripStamp() {
             // given
-            Stamp stamp1 =
-                    spy(
-                            StampFactory.create(
-                                    exploreTrip, STAMP_NAME, 0, STAMP_DEAD_LINE.plusDays(1)));
-            Stamp stamp2 = spy(StampFactory.create(exploreTrip, STAMP_NAME, 0, STAMP_DEAD_LINE));
-            List<Stamp> stamps =
-                    Stream.of(stamp1, stamp2)
-                            .sorted(Comparator.comparing(Stamp::getDeadline))
-                            .collect(Collectors.toList());
-
-            given(stampRepository.findAllByTripIdOrderByDeadlineAsc(exploreTrip.getId()))
-                    .willReturn(stamps);
+            Stamp exploreStamp = StampFixture.createStamp(exploreTrip, 0);
 
             // when
-            stampService.updateStampsOrderByTripCategoryChange(
-                    exploreTrip.getId(), TripCategory.COURSE);
+            stampService.deleteStamp(exploreTrip.getId(), exploreTrip.getCategory(), exploreStamp);
 
             // then
-            assertThat(stamp2.getStampOrder()).isEqualTo(1);
-            assertThat(stamp1.getStampOrder()).isEqualTo(2);
+            assertThat(exploreStamp.getDeletedAt()).isNotNull();
         }
     }
 
@@ -211,13 +479,84 @@ public class StampServiceTest extends BaseUnitTest {
     class ListStamps {
 
         @Test
-        @DisplayName("유효한 여행 ID로 스탬프 목록을 조회한다")
+        @DisplayName("유효한 여행 ID로 삭제된 스탬프를 제외한 스탬프 목록을 조회한다")
         void shouldGetStampsByTripId() {
+            // given
+            given(stampRepository.findAllByTripIdAndDeletedAtIsNull(courseTrip.getId()))
+                    .willReturn(List.of(courseStamp1, courseStamp2));
+
             // when
-            stampService.getStampsByTripId(courseTrip.getId());
+            List<Stamp> stamps = stampService.getStampsByTripId(courseTrip.getId());
 
             // then
-            verify(stampRepository).findAllByTripId(any());
+            verify(stampRepository).findAllByTripIdAndDeletedAtIsNull(any());
+
+            assertThat(stamps.isEmpty()).isFalse();
+            assertThat(stamps.size()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프를 조회한다")
+    class GetStamp {
+
+        @Test
+        @DisplayName("스탬프 ID로 스탬프를 조회하고, 여행 소속 및 삭제 여부를 검증하고 반환한다")
+        void shouldGetStampReturnValidStamp() {
+            // given
+            given(stampRepository.findById(any())).willReturn(Optional.ofNullable(courseStamp1));
+
+            // when
+            Stamp stamp = stampService.getValidStamp(courseTrip.getId(), courseStamp1.getId());
+
+            // then
+            verify(stampRepository).findById(any());
+
+            assertThat(stamp.getId()).isEqualTo(courseStamp1.getId());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 스탬프 ID일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenStampNotFoundById() {
+            // given
+            Long stampId = 1000L;
+
+            // when & then
+            assertThatThrownBy(() -> stampService.getValidStamp(courseTrip.getId(), stampId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(StampErrorCode.STAMP_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("여행에 속한 스탬프가 아닐 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenStampDoesNotBelongToTrip() {
+            // given
+            given(stampRepository.findById(any())).willReturn(Optional.ofNullable(courseStamp1));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    stampService.getValidStamp(
+                                            exploreTrip.getId(), courseStamp1.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(StampErrorCode.STAMP_NOT_BELONG_TO_TRIP.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 스탬프일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenStampAlreadyDeleted() {
+            // given
+            courseStamp1.updateDeletedAt();
+
+            given(stampRepository.findById(any())).willReturn(Optional.ofNullable(courseStamp1));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    stampService.getValidStamp(
+                                            courseStamp1.getId(), courseStamp1.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(StampErrorCode.STAMP_ALREADY_DELETED.getMessage());
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
@@ -1,14 +1,23 @@
 package com.ject.studytrip.stamp.fixture;
 
+import com.ject.studytrip.stamp.domain.factory.StampFactory;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.trip.domain.model.Trip;
 import java.time.LocalDate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class StampFixture {
     private static final String STAMP_NAME = "TEST STAMP NAME";
     private static final LocalDate STAMP_DEAD_LINE = LocalDate.now().plusDays(7);
 
     public static Stamp createStamp(Trip trip, int order) {
-        return Stamp.of(trip, STAMP_NAME, order, STAMP_DEAD_LINE);
+        return StampFactory.create(trip, STAMP_NAME, order, STAMP_DEAD_LINE);
+    }
+
+    public static Stamp createStampWithId(Long id, Trip trip, int order) {
+        Stamp stamp = StampFactory.create(trip, STAMP_NAME, order, STAMP_DEAD_LINE);
+        ReflectionTestUtils.setField(stamp, "id", id);
+
+        return stamp;
     }
 }

--- a/src/test/java/com/ject/studytrip/stamp/fixture/UpdateStampRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/UpdateStampRequestFixture.java
@@ -1,0 +1,35 @@
+package com.ject.studytrip.stamp.fixture;
+
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
+import java.time.LocalDate;
+import java.util.List;
+
+public class UpdateStampRequestFixture {
+    private String name = "TEST STAMP";
+    private List<Long> orderedStampIds = List.of(1L, 2L);
+    private LocalDate deadline = LocalDate.now().plusDays(1);
+
+    public UpdateStampRequestFixture withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public UpdateStampRequestFixture withOrderedStampIds(List<Long> orderedStampIds) {
+        this.orderedStampIds = orderedStampIds;
+        return this;
+    }
+
+    public UpdateStampRequestFixture withDeadline(LocalDate deadline) {
+        this.deadline = deadline;
+        return this;
+    }
+
+    public UpdateStampNameAndDeadlineRequest buildUpdateNameAndDeadline() {
+        return new UpdateStampNameAndDeadlineRequest(name, deadline);
+    }
+
+    public UpdateStampOrderRequest buildUpdateOrders() {
+        return new UpdateStampOrderRequest(orderedStampIds);
+    }
+}

--- a/src/test/java/com/ject/studytrip/stamp/helper/StampTestHelper.java
+++ b/src/test/java/com/ject/studytrip/stamp/helper/StampTestHelper.java
@@ -1,0 +1,25 @@
+package com.ject.studytrip.stamp.helper;
+
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.domain.repository.StampRepository;
+import com.ject.studytrip.stamp.fixture.StampFixture;
+import com.ject.studytrip.trip.domain.model.Trip;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StampTestHelper {
+    @Autowired private StampRepository stampRepository;
+
+    public Stamp saveStamp(Trip trip, int order) {
+        Stamp stamp = StampFixture.createStamp(trip, order);
+        return stampRepository.save(stamp);
+    }
+
+    public Stamp saveDeletedStamp(Trip trip, int order) {
+        Stamp stamp = StampFixture.createStamp(trip, order);
+        stamp.updateDeletedAt();
+
+        return stampRepository.save(stamp);
+    }
+}

--- a/src/test/java/com/ject/studytrip/stamp/presentation/controller/StampControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/presentation/controller/StampControllerIntegrationTest.java
@@ -1,0 +1,1303 @@
+package com.ject.studytrip.stamp.presentation.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ject.studytrip.BaseIntegrationTest;
+import com.ject.studytrip.auth.domain.error.AuthErrorCode;
+import com.ject.studytrip.auth.fixture.TokenFixture;
+import com.ject.studytrip.auth.helper.TokenTestHelper;
+import com.ject.studytrip.global.exception.error.CommonErrorCode;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.helper.MemberTestHelper;
+import com.ject.studytrip.stamp.domain.error.StampErrorCode;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.fixture.CreateStampRequestFixture;
+import com.ject.studytrip.stamp.fixture.UpdateStampRequestFixture;
+import com.ject.studytrip.stamp.helper.StampTestHelper;
+import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampNameAndDeadlineRequest;
+import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
+import com.ject.studytrip.trip.domain.error.TripErrorCode;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.helper.TripTestHelper;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class StampControllerIntegrationTest extends BaseIntegrationTest {
+    private static final int NEXT_STAMP_ORDER = 3;
+
+    @Autowired private MemberTestHelper memberTestHelper;
+    @Autowired private TripTestHelper tripTestHelper;
+    @Autowired private StampTestHelper stampTestHelper;
+    @Autowired private TokenTestHelper tokenTestHelper;
+
+    private String token;
+    private Member member;
+    private Trip courseTrip;
+    private Trip exploreTrip;
+    private Stamp courseStamp1;
+    private Stamp courseStamp2;
+
+    @BeforeEach
+    void setup() {
+        member = memberTestHelper.saveMember();
+        token =
+                tokenTestHelper.createAccessToken(
+                        member.getId().toString(), member.getRole().name());
+        courseTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+        exploreTrip = tripTestHelper.saveTrip(member, TripCategory.EXPLORE);
+        courseStamp1 = stampTestHelper.saveStamp(courseTrip, 1);
+        courseStamp2 = stampTestHelper.saveStamp(courseTrip, 2);
+    }
+
+    @Nested
+    @DisplayName("스탬프 생성 API")
+    class CreateStamp {
+        private final CreateStampRequestFixture createStampRequestFixture =
+                new CreateStampRequestFixture();
+
+        private ResultActions getResultActions(
+                String token, Object tripId, CreateStampRequest request) throws Exception {
+            return mockMvc.perform(
+                    post("/api/trips/{tripId}/stamps", tripId)
+                            .header(HttpHeaders.AUTHORIZATION, TokenFixture.TOKEN_PREFIX + token)
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .content(objectMapper.writeValueAsString(request)));
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 특정 여행의 스탬프를 생성하고, 여행 총 스탬프 수가 증가한다")
+        void shouldCreateStamp() throws Exception {
+            // given
+            CreateStampRequest request =
+                    createStampRequestFixture.withStampOrder(NEXT_STAMP_ORDER).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.stampId").isNumber());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+        void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+            // given
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions("", courseTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+            CreateStampRequest request = createStampRequestFixture.build();
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("스탬프를 생성하는데 필요한 필수 요청 값이 누락되거나 유효하지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidRequiredFields() throws Exception {
+            // given
+            CreateStampRequest request = createStampRequestFixture.withName("").build();
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("스탬프 마감일이 과거일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenDeadlineIsInThePast() throws Exception {
+            // given
+            CreateStampRequest request =
+                    createStampRequestFixture.withDeadline(LocalDate.now().minusDays(1)).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenAlreadyTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, deleted.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("스탬프 마감일이 여행의 종료일보다 이후일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenStampDeadlineIsAfterTripEndDate() throws Exception {
+            // given
+            CreateStampRequest request =
+                    createStampRequestFixture
+                            .withDeadline(courseTrip.getEndDate().plusDays(1))
+                            .build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_DEADLINE_EXCEEDS_TRIP_END_DATE
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("탐험형 여행에 순서가 존재하는 스탬프를 추가하면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenStampOrderExistsInExplorationTrip() throws Exception {
+            // given
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, exploreTrip.getId(), request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("코스형 여행에 유효하지 않은 순서(중복, 범위 이탈)가 존재하는 스탬프를 추가하면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenStampOrderOutOfRangeInCourseTrip() throws Exception {
+            // given
+            CreateStampRequest request = createStampRequestFixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 수정 API")
+    class UpdateStamp {
+        private final UpdateStampRequestFixture updateStampRequestFixture =
+                new UpdateStampRequestFixture();
+
+        @Nested
+        @DisplayName("스탬프 이름, 마감일 수정")
+        class UpdateNameAndDeadline {
+            private ResultActions getResultActions(
+                    String token,
+                    Object tripId,
+                    Object stampId,
+                    UpdateStampNameAndDeadlineRequest request)
+                    throws Exception {
+                return mockMvc.perform(
+                        patch("/api/trips/{tripId}/stamps/{stampId}", tripId, stampId)
+                                .header(
+                                        HttpHeaders.AUTHORIZATION,
+                                        TokenFixture.TOKEN_PREFIX + token)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(objectMapper.writeValueAsString(request)));
+            }
+
+            @Test
+            @DisplayName("유효한 요청으로 스탬프의 이름과 마감일을 수정한다")
+            void shouldUpdateStampNameAndDeadline() throws Exception {
+                // given
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, courseTrip.getId(), courseStamp1.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true));
+            }
+
+            @Test
+            @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+            void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+                // given
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+                // when
+                ResultActions resultActions =
+                        getResultActions("", courseTrip.getId(), courseStamp1.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isUnauthorized())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+            void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+                // given
+                String tripId = "abc";
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, tripId, courseStamp1.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("PathVariable 스탬프 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+            void shouldThrowExceptionWhenStampIdTypeMismatch() throws Exception {
+                // given
+                String stampId = "abc";
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, courseTrip.getId(), stampId, request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("수정한 스탬프 마감일이 과거일 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenStampDeadlineCannotBeInPast() throws Exception {
+                // given
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture
+                                .withDeadline(LocalDate.now().minusDays(1))
+                                .buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, courseTrip.getId(), courseStamp1.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+            void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+                // given
+                Long tripId = 10000L;
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, tripId, courseStamp1.getId(), request);
+
+                // when & then
+                resultActions
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("요청한 사용자가 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+            void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+                // given
+                Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+                Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+                Stamp newStamp = stampTestHelper.saveStamp(newTrip, 1);
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, newTrip.getId(), newStamp.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenAlreadyDeletedTrip() throws Exception {
+                // given
+                Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, deleted.getId(), courseStamp1.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                TripErrorCode.TRIP_ALREADY_DELETED
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 스탬프 ID 라면 404 예외가 발생한다")
+            void shouldThrowExceptionWhenInvalidStampId() throws Exception {
+                // given
+                Long stampId = 10000L;
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, courseTrip.getId(), stampId, request);
+
+                // when & then
+                resultActions
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(StampErrorCode.STAMP_NOT_FOUND.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("여행에 속한 스탬프가 아닌 경우 403 예외가 발생한다")
+            void shouldThrowExceptionWhenStampTripMisMatch() throws Exception {
+                // given
+                Stamp newStamp = stampTestHelper.saveStamp(exploreTrip, 0);
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, courseTrip.getId(), newStamp.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("삭제된 스탬프일 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenAlreadyDeletedStamp() throws Exception {
+                // given
+                Stamp newStamp = stampTestHelper.saveDeletedStamp(exploreTrip, 0);
+                UpdateStampNameAndDeadlineRequest request =
+                        updateStampRequestFixture.buildUpdateNameAndDeadline();
+
+                // when
+                ResultActions resultActions =
+                        getResultActions(token, exploreTrip.getId(), newStamp.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode.STAMP_ALREADY_DELETED
+                                                        .getStatus()
+                                                        .value()));
+            }
+        }
+
+        @Nested
+        @DisplayName("스탬프 순서 수정")
+        class UpdateOrders {
+
+            private ResultActions getResultActions(
+                    String token, Object tripId, UpdateStampOrderRequest request) throws Exception {
+                return mockMvc.perform(
+                        put("/api/trips/{tripId}/stamps/orders", tripId)
+                                .header(
+                                        HttpHeaders.AUTHORIZATION,
+                                        TokenFixture.TOKEN_PREFIX + token)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(objectMapper.writeValueAsString(request)));
+            }
+
+            @Test
+            @DisplayName("유효한 요청으로 스탬프의 순서를 수정한다")
+            void shouldUpdateStampOrders() throws Exception {
+                // given
+                UpdateStampOrderRequest request =
+                        new UpdateStampRequestFixture()
+                                .withOrderedStampIds(
+                                        List.of(courseStamp2.getId(), courseStamp1.getId()))
+                                .buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true));
+            }
+
+            @Test
+            @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+            void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+                // given
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions("", courseTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isUnauthorized())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+            void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+                // given
+                String tripId = "abc";
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, tripId, request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+            void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+                // given
+                Long tripId = 10000L;
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, tripId, request);
+
+                // when & then
+                resultActions
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("요청한 사용자가 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+            void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+                // given
+                Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+                Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+            }
+
+            @Test
+            @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenAlreadyDeletedTrip() throws Exception {
+                // given
+                Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, deleted.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                TripErrorCode.TRIP_ALREADY_DELETED
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("탐험형 여행이지만 스탬프 순서 변경을 요청한 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenRequestUpdateStampOrderForExploreTrip() throws Exception {
+                // given
+                Stamp exploreStamp = stampTestHelper.saveStamp(exploreTrip, 0);
+                UpdateStampOrderRequest request = updateStampRequestFixture.buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, exploreTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode
+                                                        .CANNOT_UPDATE_ORDER_FOR_EXPLORATION_TRIP
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("순서 변경을 요청한 ID 리스트에 존재하지 않는 스탬프가 있는 경우 400 예외가 발생한다")
+            void shouldThrow400WhenStampIdInUpdateOrderRequestIsInvalid() throws Exception {
+                // given
+                UpdateStampOrderRequest request =
+                        updateStampRequestFixture
+                                .withOrderedStampIds(List.of(100L, 200L))
+                                .buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode.INVALID_STAMP_ID_IN_REQUEST
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("요청한 여행에 속한 스탬프가 아닌 경우 403 예외가 발생한다")
+            void shouldThrowExceptionWhenStampTripMisMatch() throws Exception {
+                // given
+                Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+                UpdateStampOrderRequest request =
+                        updateStampRequestFixture
+                                .withOrderedStampIds(
+                                        List.of(courseStamp1.getId(), courseStamp2.getId()))
+                                .buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                        .getStatus()
+                                                        .value()));
+            }
+
+            @Test
+            @DisplayName("삭제된 스탬프일 경우 400 예외가 발생한다")
+            void shouldThrowExceptionWhenAlreadyDeletedStamp() throws Exception {
+                // given
+                Stamp newStamp = stampTestHelper.saveDeletedStamp(courseTrip, NEXT_STAMP_ORDER);
+                UpdateStampOrderRequest request =
+                        updateStampRequestFixture
+                                .withOrderedStampIds(
+                                        List.of(
+                                                newStamp.getId(),
+                                                courseStamp2.getId(),
+                                                courseStamp1.getId()))
+                                .buildUpdateOrders();
+
+                // when
+                ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
+
+                // then
+                resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(
+                                jsonPath("$.status")
+                                        .value(
+                                                StampErrorCode.STAMP_ALREADY_DELETED
+                                                        .getStatus()
+                                                        .value()));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 삭제 API")
+    class DeleteStamp {
+        private ResultActions getResultActions(String token, Object tripId, Object stampId)
+                throws Exception {
+            return mockMvc.perform(
+                    delete("/api/trips/{tripId}/stamps/{stampId}", tripId, stampId)
+                            .header(HttpHeaders.AUTHORIZATION, TokenFixture.TOKEN_PREFIX + token));
+        }
+
+        @Test
+        @DisplayName("여행의 특정 스탬프를 삭제하고, 여행의 총 스탬프 수가 감소한다")
+        void shouldDeleteStamp() throws Exception {
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, courseTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+        void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+            // when
+            ResultActions resultActions =
+                    getResultActions("", courseTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 스탬프 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenStampIdTypeMismatch() throws Exception {
+            // given
+            String stampId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), stampId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, courseStamp1.getId());
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 사용자가 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenAlreadyDeletedTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, deleted.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 스탬프 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidStampId() throws Exception {
+            // given
+            Long stampId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), stampId);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(StampErrorCode.STAMP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행에 속한 스탬프가 아닌 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenStampTripMisMatch() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 목록 조회 API")
+    class ListStamps {
+        private ResultActions getResultActions(String token, Object tripId) throws Exception {
+            return mockMvc.perform(
+                    get("/api/trips/{tripId}/stamps", tripId)
+                            .header(HttpHeaders.AUTHORIZATION, TokenFixture.TOKEN_PREFIX + token));
+        }
+
+        @Test
+        @DisplayName("여행 ID로 여행에 속한 스탬프 목록을 조회하고 반환한다")
+        void shouldGetStampsByTripIdReturnStamps() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+        void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions("", courseTrip.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 사용자가 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenAlreadyDeletedTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions = getResultActions(token, deleted.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 상세 조회 API")
+    class GetStamp {
+        private ResultActions getResultActions(String token, Object tripId, Object stampId)
+                throws Exception {
+            return mockMvc.perform(
+                    get("/api/trips/{tripId}/stamps/{stampId}", tripId, stampId)
+                            .header(HttpHeaders.AUTHORIZATION, TokenFixture.TOKEN_PREFIX + token));
+        }
+
+        @Test
+        @DisplayName("특정 스탬프 ID로 조회하고 스탬프 정보를 반환한다")
+        void shouldGetStampReturnStampInfo() throws Exception {
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, courseTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 예외가 발생한다")
+        void shouldThrowExceptionWhenUnauthenticated() throws Exception {
+            // when
+            ResultActions resultActions =
+                    getResultActions("", courseTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 스탬프 ID 타입이 올바르지 않으면 400 예외가 발생한다")
+        void shouldThrowExceptionWhenStampIdTypeMismatch() throws Exception {
+            // given
+            String stampId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), stampId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, courseStamp1.getId());
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 사용자가 여행의 소유자가 아닐 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenAlreadyDeletedTrip() throws Exception {
+            // given
+            Trip deletedTrip = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, deletedTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 스탬프 ID 라면 404 예외가 발생한다")
+        void shouldThrowExceptionWhenInvalidStampId() throws Exception {
+            // given
+            Long stampId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, courseTrip.getId(), stampId);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(StampErrorCode.STAMP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 스탬프가 해당 여행에 속해있지 않을 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenStampTripMisMatch() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), courseStamp1.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 스탬프일 경우 400 예외가 발생한다")
+        void shouldThrowExceptionWhenAlreadyDeletedStamp() throws Exception {
+            // given
+            Stamp deletedStamp = stampTestHelper.saveDeletedStamp(exploreTrip, 0);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, exploreTrip.getId(), deletedStamp.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
@@ -49,7 +49,7 @@ public class TripServiceTest extends BaseUnitTest {
     @BeforeEach
     void setup() {
         member = MemberFixture.createMemberFromKakaoWithId(1L);
-        trip = TripFixture.createTripWithId(1L, member);
+        trip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
     }
 
     @Nested
@@ -198,6 +198,32 @@ public class TripServiceTest extends BaseUnitTest {
             assertThatThrownBy(() -> tripService.updateTrip(member.getId(), deleted, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(TripErrorCode.TRIP_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("여행의 총 스탬프 수를 +1 증가시킨다")
+        void shouldIncreaseTotalStamps() {
+            // given
+            int tripTotalStamps = trip.getTotalStamps();
+
+            // when
+            trip.increaseTotalStamps();
+
+            // then
+            assertThat(trip.getTotalStamps()).isEqualTo(tripTotalStamps + 1);
+        }
+
+        @Test
+        @DisplayName("여행의 총 스탬프 수를 -1 감소시킨다")
+        void shouldDecreaseTotalStamps() {
+            // given
+            int tripTotalStamps = trip.getTotalStamps();
+
+            // when
+            trip.decreaseTotalStamps();
+
+            // then
+            assertThat(trip.getTotalStamps()).isEqualTo(tripTotalStamps - 1);
         }
     }
 

--- a/src/test/java/com/ject/studytrip/trip/fixture/TripFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/TripFixture.java
@@ -19,15 +19,10 @@ public class TripFixture {
                 member, TRIP_NAME, TRIP_MEMO, category, TRIP_END_DATE, TRIP_TOTAL_STAMPS);
     }
 
-    public static Trip createTripWithId(Long id, Member member) {
+    public static Trip createTripWithId(Long id, Member member, TripCategory category) {
         Trip trip =
                 TripFactory.create(
-                        member,
-                        TRIP_NAME,
-                        TRIP_MEMO,
-                        TRIP_CATEGORY_COURSE,
-                        TRIP_END_DATE,
-                        TRIP_TOTAL_STAMPS);
+                        member, TRIP_NAME, TRIP_MEMO, category, TRIP_END_DATE, TRIP_TOTAL_STAMPS);
         ReflectionTestUtils.setField(trip, "id", id);
 
         return trip;


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ Stamp 관련 기능 구현
1. **스탬프 생성 기능**
- 특정 여행에 단일 스탬프를 등록, 생성하는 기능 구현
- 기존 스탬프 목록에 새로 추가된 스탬프를 포함해 하나의 리스트로 구성하고, 해당 리스트를 기반으로 순서를 검증하도록 구현 
- 코스형 여행일 경우, 성공적으로 생성되면 소속된 여행의 `totalStamps` 필드 값을 `+1` 처리하도록 구성
- 검증 항목
```
[ 여행 유효성 검증 ]
- 존재하는 여행 ID인지
- 요청한 사용자가 여행의 소유자인지
- 삭제된 여행이 아닌지

[ 스탬프 마감일 검증 ]
- 마감일이 과거가 아닌지
- 여행 종료일 이후가 아닌지

[ 스탬프 순서 검증 ]
- 탐험형 여행에서 순서가 존재하는지 여부
- 코스형 여행의 순서 범위
- 코스형 여행의 중복 순서
``` 
<br/>

2. **스탬프 이름 또는 마감일 수정 기능**
- PATCH 방식으로 이름 또는 마감일 중 수정할 필드만 선택적으로 수정 가능하도록 구현
- 검증 항목
```
[ 여행 유효성 검증 ]
- 존재하는 여행 ID인지
- 요청한 사용자가 여행의 소유자인지
- 삭제된 여행이 아닌지

[ 스탬프 유효성 검증 ]
- 존재하는 스탬프 ID인지
- 해당 스탬프가 요청한 여행에 속해 있는지
- 삭제된 스탬프인지

[ 스탬프 마감일 검증 ]
- 마감일이 과거가 아닌지
- 여행 종료일 이후가 아닌지
``` 
<br/>

3. **스탬프 순서 변경 기능**
- 클라이언트에서 최종적인 순서로 정렬된 스탬프 ID 리스트를 전달받아서 해당 순서대로 업데이트 하도록 구성
- 검증 항목
```
[여행 유효성 검증]
- 존재하는 여행 ID인지
- 요청한 사용자가 여행의 소유자인지
- 삭제된 여행이 아닌지

[ 최종 순서로 정렬된 스탬프 ID 리스트 검증 ]
- 탐험형일 경우 순서 변경 불가능
- 코스형이지만 요청한 스탬프 ID 리스트와 실제 스탬프 목록의 개수가 다른 경우

[ 스탬프 유효성 검증 ]
- 해당 스탬프가 요청한 여행에 속해 있는지
- 삭제된 스탬프인지
``` 
<br/>

4. **스탬프 삭제 기능**
- 스탬프의 `deletedAt` 필드를 현재 시간으로 업데이트해서 soft delete 방식을 적용
- ⭐  당장은 `Stamp`의 `deletedAt` 필드만 업데이트하도록 구성했는데, 삭제 로직은 더 구상을 해보고 추후 업데이트할 예정입니다
- 만약 코스형 여행의 스탬프가 삭제될 경우, 여행의 스탬프 목록에서 삭제된 스탬프의 `stampOrder`보다 큰 순서를 가진 스탬프들을 조회해 -1씩 재정렬하도록 구성 -> `StampQueryRepository.findStampsToShiftAfterOrder()`
- 해당 여행의 `totalStamps` 필드 값을 `-1` 감소 처리
- 검증 항목
```
[ 여행 유효성 검증 ]
- 존재하는 여행 ID인지
- 요청한 사용자가 여행의 소유자인지
- 삭제된 여행이 아닌지

[ 스탬프 유효성 검증 ]
- 존재하는 스탬프 ID인지
- 해당 스탬프가 요청한 여행에 속해 있는지
- 삭제된 스탬프인지
``` 
<br/>

5. **스탬프 목록 조회 기능**
- 특정 여행의 모든 스탬프 목록을 조회하는 기능 구현
- `deletedAt IS NULL` 조건으로 삭제되지 않은 스탬프만 조회되도록 구성

<br/>

6. **특정 스탬프 상세 조회 기능**
- 요청한 `StampId`로 해당 스탬프를 조회하고, 해당 스탬프에 속한 모든 미션 목록도 함께 조회되도록 구성
- 검증 항목
```
[ 여행 유효성 검증 ]
- 존재하는 여행 ID인지
- 요청한 사용자가 여행의 소유자인지
- 삭제된 여행이 아닌지

[ 스탬프 유효성 검증 ]
- 존재하는 스탬프 ID인지
- 해당 스탬프가 요청한 여행에 속해 있는지
- 삭제된 스탬프인지
``` 

<br/>

### ✅ Trip Service 로직 추가
-  `TripService.getValidTrip()` 메서드를 추가해, 여행 소유자 검증 및 삭제 검증을 수행하고 유효한 `Trip`을 조회할 수 있도록 구성
: PR을 병합한 이후에 `TripService` 또는 Trip 정보를 사용하는 영역에 기존 `getTrip()` 메서드를 호출하는 부분을 `getValidTrip()` 메서드로 교체할 예정입니다
-  스탬프를 생성하거나 삭제할 경우 해당 여행의 총 스탬프 개수를 변경하기 위해 `TripService` 에 `totalStamps` 필드 값을 증가시키는 `increaseTotalStamps()` 와 감소시키는 `decreaseTotalStamps()` 메서드 추가

<br/>

### ✅ Mission 관련 로직 추가
- 스탬프 상세 조회 로직에서 해당 스탬프에 포함된 미션 목록도 함께 응답할 수 있도록 `MissionService.getMissionsByStamp()` 메서드 추가
- `mission.application.dto.MissionInfo` 를 구성해 `Mission` 도메인 정보를 응답하도록 구성

<br/>

### ✅ 테스트 추가
- `TripServiceTest`에 총 스탬프 수 증가/감소 기능 단위 테스트 추가
- 테스트용 `Stamp`를 생성하는 `StampTestHelper` 클래스 추가
- `StampFixture`에 임의의 ID를 지정할 수 있는 `createStampWithId()` 메서드 추가
- `StampServiceTest` 단위 테스트 구성
- `StampControllerIntegrationTest` 통합 테스트 구성


<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #23 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

- 테스트 코드를 작성하는 범위에 대한 기준이 명확하지 않아서 혼란스러운 부분이 있어요. 어느 경우까지 테스트를 작성해야 하는지, 응답 값은 어디까지 검증할지 등을 정리하기 위해 한 번 회의를 진행하면 좋을 것 같아요.
- 현재 저희 서비스의 삭제는 `soft delete` 방식으로 처리되고 있어서 하나의 엔티티를 삭제할 때 연관된 다른 엔티티들도 어떻게 함께 삭제 처리할지에 대해 조금 더 고민이 필요할 것 같아요. 우선은 주요 `CRU(생성, 수정, 조회)` 로직을 먼저 구현하고 이후에 삭제 로직을 구상해 완성해나가는 것이 좋을 것 같아요.