### PR TITLE
refactor: 여행 정보 조회 시 getTrip → getValidTrip로 통합 리팩토링(#30)

### DIFF
--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
@@ -47,7 +47,7 @@ public class TripFacade {
     @Transactional
     public void updateTrip(Long memberId, Long tripId, UpdateTripRequest request) {
         Member member = memberService.getMember(memberId);
-        Trip trip = tripService.getTrip(tripId);
+        Trip trip = tripService.getValidTrip(member.getId(), tripId);
 
         tripService.updateTrip(member.getId(), trip, request);
 
@@ -59,7 +59,7 @@ public class TripFacade {
     @Transactional
     public void deleteTrip(Long memberId, Long tripId) {
         Member member = memberService.getMember(memberId);
-        Trip trip = tripService.getTrip(tripId);
+        Trip trip = tripService.getValidTrip(member.getId(), tripId);
         tripService.deleteTrip(member.getId(), trip);
 
         // TODO : 추후 엔티티가 생성되면, 여행과 관련된 엔티티를 모두 soft delete 하는 로직 추가
@@ -88,8 +88,10 @@ public class TripFacade {
         return new SliceImpl<>(tripInfos, tripSlice.getPageable(), tripSlice.hasNext());
     }
 
-    public TripDetail getTrip(Long tripId) {
-        Trip trip = tripService.getTrip(tripId);
+    public TripDetail getTrip(Long memberId, Long tripId) {
+        Member member = memberService.getMember(memberId);
+        Trip trip = tripService.getValidTrip(member.getId(), tripId);
+
         int dDay = calculateDDay(trip.getEndDate());
         int progress = calculateProgress(trip.getTotalStamps(), trip.getCompletedStamps());
 

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripService.java
@@ -45,9 +45,7 @@ public class TripService {
         TripCategory category = null;
         if (request.category() != null) category = TripCategory.from(request.category());
 
-        TripPolicy.validateOwner(memberId, trip);
         TripPolicy.validateEndDateIsNotBeforeStartDate(trip.getStartDate(), request.endDate());
-        TripPolicy.validateNotDeleted(trip);
 
         trip.update(request.name(), request.memo(), category, request.endDate());
     }
@@ -61,22 +59,15 @@ public class TripService {
     }
 
     public void deleteTrip(Long memberId, Trip trip) {
-        TripPolicy.validateOwner(memberId, trip);
-
         trip.updateDeletedAt();
 
         // TODO : 삭제는 로직을 더 구상해본 후 추후 리팩토링
     }
 
     public Trip getTrip(Long tripId) {
-        Trip trip =
-                tripRepository
-                        .findById(tripId)
-                        .orElseThrow(() -> new CustomException(TripErrorCode.TRIP_NOT_FOUND));
-
-        TripPolicy.validateNotDeleted(trip);
-
-        return trip;
+        return tripRepository
+                .findById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorCode.TRIP_NOT_FOUND));
     }
 
     public Trip getValidTrip(Long memberId, Long tripId) {

--- a/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
@@ -102,8 +102,9 @@ public class TripController {
     @Operation(summary = "여행 상세 조회", description = "특정 여행을 조회하는 API 입니다.")
     @GetMapping("/{tripId}")
     public ResponseEntity<StandardResponse> loadTripDetail(
+            @AuthenticationPrincipal String memberId,
             @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId) {
-        TripDetail result = tripFacade.getTrip(tripId);
+        TripDetail result = tripFacade.getTrip(Long.valueOf(memberId), tripId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripServiceTest.java
@@ -159,19 +159,6 @@ public class TripServiceTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("수정할 권한이 없는 사용자일 경우 예외가 발생한다")
-        void shouldThrowExceptionWhenNoPermission() {
-            // given
-            Member newMember = MemberFixture.createMemberFromKakao();
-            UpdateTripRequest request = new UpdateTripRequestFixture().build();
-
-            // When & Then
-            assertThatThrownBy(() -> tripService.updateTrip(newMember.getId(), trip, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(TripErrorCode.NOT_TRIP_OWNER.getMessage());
-        }
-
-        @Test
         @DisplayName("여행 종료일이 시작일보다 이전일 경우 예외가 발생한다")
         void shouldThrowExceptionWhenEndDateIsBeforeStartDate() {
             // given
@@ -185,19 +172,6 @@ public class TripServiceTest extends BaseUnitTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(
                             TripErrorCode.TRIP_END_DATE_BEFORE_START_DATE.getMessage());
-        }
-
-        @Test
-        @DisplayName("이미 삭제된 여행일 경우 예외가 발생한다")
-        void shouldThrowExceptionWhenAlreadyDeleted() {
-            // given
-            Trip deleted = TripFixture.createDeletedTrip(member);
-            UpdateTripRequest request = new UpdateTripRequestFixture().build();
-
-            // When & Then
-            assertThatThrownBy(() -> tripService.updateTrip(member.getId(), deleted, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(TripErrorCode.TRIP_ALREADY_DELETED.getMessage());
         }
 
         @Test
@@ -240,18 +214,6 @@ public class TripServiceTest extends BaseUnitTest {
             // then
             assertThat(trip.getDeletedAt()).isNotNull();
         }
-
-        @Test
-        @DisplayName("삭제할 권한이 없는 경우 예외가 발생한다")
-        void shouldThrowExceptionWhenNoPermission() {
-            // given
-            Member newMember = MemberFixture.createMemberFromKakao();
-
-            // when & then
-            assertThatThrownBy(() -> tripService.deleteTrip(newMember.getId(), trip))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(TripErrorCode.NOT_TRIP_OWNER.getMessage());
-        }
     }
 
     @Nested
@@ -273,6 +235,33 @@ public class TripServiceTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("특정 여행 ID로 DB에서 조회한 후 유효한 여행을 반환한다")
+        void shouldGetTripByTripIdReturnValidTrip() {
+            // given
+            given(tripRepository.findById(trip.getId())).willReturn(Optional.of(trip));
+
+            // when
+            Trip result = tripService.getValidTrip(member.getId(), trip.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(trip.getId());
+        }
+
+        @Test
+        @DisplayName("여행의 소유자가 아닐 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() {
+            // given
+            Member newMember = MemberFixture.createMemberFromKakao();
+            given(tripRepository.findById(trip.getId())).willReturn(Optional.of(trip));
+
+            // When & Then
+            assertThatThrownBy(() -> tripService.getValidTrip(newMember.getId(), trip.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(TripErrorCode.NOT_TRIP_OWNER.getMessage());
+        }
+
+        @Test
         @DisplayName("이미 삭제된 여행일 경우 예외가 발생한다")
         void shouldThrowExceptionWhenAlreadyTrip() {
             // given
@@ -280,7 +269,7 @@ public class TripServiceTest extends BaseUnitTest {
             given(tripRepository.findById(any())).willReturn(Optional.of(deleted));
 
             // when & then
-            assertThatThrownBy(() -> tripService.getTrip(trip.getId()))
+            assertThatThrownBy(() -> tripService.getValidTrip(member.getId(), deleted.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(TripErrorCode.TRIP_ALREADY_DELETED.getMessage());
         }

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
@@ -582,6 +582,20 @@ public class TripControllerIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
+        @DisplayName("여행의 소유자가 아닐 경우 403 예외가 발생한다")
+        void shouldThrowExceptionWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "test");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId());
+
+            // then
+            resultActions.andExpect(status().is(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
         @DisplayName("이미 삭제된 여행일 경우 400 예외가 발생한다")
         void shouldThrowExceptionWhenAlreadyDeleted() throws Exception {
             // given


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 여행 조회 로직을 getValidTrip() 으로 통합
- 기존에는 `getTrip()` 메서드로 삭제 여부만 검증하고 소유자 검증은 각 기능에서 별도로 수행했지만, 중복된 코드를 줄이고 각 역할을 분리하기 위해 `getValidTrip()` 메서드 하나에서 삭제 여부 및 소유자 검증을 모두 수행하도록 변경하고, 검증된 여행 정보가 필요한 모든 곳에서 `getValidTrip()` 메서드를 사용하도록 리팩토링
- `getValidTrip()` 메서드는 검증을 수행해 유효한 여행 정보 조회 역할을 담당하고, `getTrip()` 메서드는 단순 여행 조회 용도로 역할을 분리

### ✅ TripServiceTest 및 TripControllerIntegrationTest 수정
- 중복된 검증 로직을 제거하면서 `TripServiceTest` 내 관련 테스트 제거
- 여행 상세 조회 시 **소유자 검증 테스트**를 `TripServiceTest` 및 `TripControllerIntegrationTest`에 추가

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #30 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-