### PR TITLE
fix: cors 에러 해결(#35)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/WebSecurityConfig.java
@@ -2,9 +2,12 @@ package com.ject.studytrip.global.config;
 
 import com.ject.studytrip.auth.infra.filter.JwtFilter;
 import com.ject.studytrip.global.common.constants.SwaggerUrlConstants;
+import com.ject.studytrip.global.common.constants.UrlConstants;
 import com.ject.studytrip.global.config.properties.TokenProperties;
 import com.ject.studytrip.global.security.CustomAccessDeniedHandler;
 import com.ject.studytrip.global.security.CustomAuthenticationEntryPoint;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -89,6 +92,9 @@ public class WebSecurityConfig {
         //  - prod: PROD_DOMAIN 만 허용
         //  - Spring Active Profile 기반 분기 필요
         //  - 서비스 도메인, 서버 운영 환경 설정 완료 시 작업
+        List<String> allowedOrigins =
+                Arrays.stream(UrlConstants.values()).map(UrlConstants::getValue).toList();
+        config.setAllowedOrigins(allowedOrigins);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ CORS 문제 해결
- 클라이언트 로컬 환경에서 API를 테스트할 때 CORS 에러가 발생해 `Spring Security` `CORS` 설정 구성
- `WebSecurityConfig` `cors` 설정에 `setAllowedOrigins(List<String> origins)` 코드를 추가해 로컬/개발 전용 도메인 origin 허용 처리
: 추후 클라이언트 개발/운영 환경도 배포되면, `UrlConstants` 에 추가 예정

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #35 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-