### PR TITLE
feat: 뽀모도로 엔티티 구현(#33)

### DIFF
--- a/src/main/java/com/ject/studytrip/pomodoro/domain/factory/PomodoroFactory.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/factory/PomodoroFactory.java
@@ -1,0 +1,17 @@
+package com.ject.studytrip.pomodoro.domain.factory;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PomodoroFactory {
+    public static Pomodoro create(
+            DailyGoal dailyGoal,
+            int focusDurationInSeconds,
+            int focusCount,
+            int breakDurationInSeconds) {
+        return Pomodoro.of(dailyGoal, focusDurationInSeconds, focusCount, breakDurationInSeconds);
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
@@ -1,0 +1,43 @@
+package com.ject.studytrip.pomodoro.domain.model;
+
+import com.ject.studytrip.global.common.entity.BaseTimeEntity;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class Pomodoro extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_goal_id", nullable = false)
+    private DailyGoal dailyGoal;
+
+    private int focusDurationInSeconds; // 집중 시간(초)
+    private int focusCount; // 집중 세션 횟수
+    private int breakDurationInSeconds; // 휴식 시간(초)
+    private int totalFocusTimeInSeconds; // 총 집중 시간(초)
+
+    // TODO : 추후 집중 세션 개수와 휴식 시간을 설정할 수 있는 기능이 추가될 경우 리팩토링
+    // 우선은 고정 값 세팅
+    public static Pomodoro of(
+            DailyGoal dailyGoal,
+            int focusDurationInSeconds,
+            int focusCount,
+            int breakDurationInSeconds) {
+        return Pomodoro.builder()
+                .dailyGoal(dailyGoal)
+                .focusDurationInSeconds(focusDurationInSeconds)
+                .focusCount(1)
+                .breakDurationInSeconds(0)
+                .totalFocusTimeInSeconds(0)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ Pomodoro 엔티티 구현
- 데일리 목표 세션에서 학습에 집중한 시간을 기록하기 위한 `Pomodoro` 엔티티 구성
- 집중 시간, 휴식 시간, 총 집중 시간(총 학습 시간) 필드를 초 단위로 관리하도록 설계
- 1차 MVP 에서는 집중 시간만 설정하지만, 추후 알림 기능이 도입되면 `집중 세션 개수(focusCount)`와 `휴식 시간(breakDurationInSeconds)`을 설정할 수 있도록 필드 구성
```
> 현재는 Pomodoro 엔티티가 생성될 때, `focusCount = 1`, `breakDurationInSeconds = 0` 고정 값이 설정되도록 구성하고 추후 리팩토링 예정
> 휴식 세션 개수는 설정한 `focusCount - 1`로 계산해 적용할 예정
``` 
- 여행이 완료된 후 리포트를 생성할 때 총 학습한 시간 계산을 위해 `totalFocusTimeInSeconds` 필드 추가
```
> 이 값은 클라이언트에서 총 학습 시간을 계산하고, 서버로 요청하는 API로 구현할 예정
```

<br/>

### ✅ PomodoroFactory 클래스 구현
- `Pomodoro` 엔티티 생성을 책임지는 `PomodoroFactory.create()` 메서드 구현

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #33

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-