### PR TITLE
feat: 데일리 목표 관련 기능 구현(#38)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/application/dto/DailyMissionInfo.java
+++ b/src/main/java/com/ject/studytrip/mission/application/dto/DailyMissionInfo.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.mission.application.dto;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+
+public record DailyMissionInfo(Long dailyMissionId, MissionInfo missionInfo) {
+    public static DailyMissionInfo from(DailyMission dailyMission) {
+        return new DailyMissionInfo(
+                dailyMission.getId(), MissionInfo.from(dailyMission.getMission()));
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/application/dto/MissionInfo.java
+++ b/src/main/java/com/ject/studytrip/mission/application/dto/MissionInfo.java
@@ -6,6 +6,7 @@ import com.ject.studytrip.mission.domain.model.Mission;
 public record MissionInfo(
         Long missionId,
         String missionName,
+        String missionMemo,
         int missionOrder,
         boolean completed,
         String createdAt,
@@ -15,6 +16,7 @@ public record MissionInfo(
         return new MissionInfo(
                 mission.getId(),
                 mission.getName(),
+                mission.getMemo(),
                 mission.getMissionOrder(),
                 mission.isCompleted(),
                 DateUtil.formatDateTime(mission.getCreatedAt()),

--- a/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionService.java
@@ -1,0 +1,50 @@
+package com.ject.studytrip.mission.application.service;
+
+import com.ject.studytrip.mission.domain.factory.DailyMissionFactory;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.policy.DailyMissionPolicy;
+import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DailyMissionService {
+    private final DailyMissionRepository dailyMissionRepository;
+    private final DailyMissionQueryRepository dailyMissionQueryRepository;
+
+    public List<DailyMission> createDailyMissions(DailyGoal dailyGoal, List<Mission> missions) {
+        List<DailyMission> dailyMissions =
+                missions.stream()
+                        .map(mission -> DailyMissionFactory.create(mission, dailyGoal))
+                        .toList();
+
+        return dailyMissionRepository.saveAll(dailyMissions);
+    }
+
+    public void deleteDailyMission(DailyMission dailyMission) {
+        dailyMission.updateDeletedAt();
+    }
+
+    public List<DailyMission> getValidDailyMissionsByIds(
+            Long dailyGoalId, List<Long> dailyMissionIds) {
+        List<DailyMission> dailyMissions = dailyMissionRepository.findAllByIdIn(dailyMissionIds);
+
+        DailyMissionPolicy.validateExistAll(dailyMissions, dailyMissionIds);
+        dailyMissions.forEach(
+                dailyMission -> {
+                    DailyMissionPolicy.validateBelongsToDailyGoal(dailyMission, dailyGoalId);
+                    DailyMissionPolicy.validateNotDeleted(dailyMission);
+                });
+
+        return dailyMissions;
+    }
+
+    public List<DailyMission> getDailyMissionsByDailyGoal(Long dailyGoalId) {
+        return dailyMissionQueryRepository.findAllByDailyGoalIdFetchJoinMission(dailyGoalId);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
@@ -6,6 +6,7 @@ import com.ject.studytrip.mission.domain.error.MissionErrorCode;
 import com.ject.studytrip.mission.domain.factory.MissionFactory;
 import com.ject.studytrip.mission.domain.model.Mission;
 import com.ject.studytrip.mission.domain.policy.MissionPolicy;
+import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
 import com.ject.studytrip.mission.domain.repository.MissionRepository;
 import com.ject.studytrip.mission.presentation.dto.request.CreateMissionRequest;
 import com.ject.studytrip.mission.presentation.dto.request.UpdateMissionOrderRequest;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MissionService {
     private final MissionRepository missionRepository;
+    private final MissionQueryRepository missionQueryRepository;
 
     @Transactional
     public Mission createMission(Stamp stamp, CreateMissionRequest request) {
@@ -96,6 +98,23 @@ public class MissionService {
         validateMissionIsActiveAndBelongsToStamp(stampId, mission);
 
         return mission;
+    }
+
+    public List<Mission> getValidMissionsWithStamp(List<Long> missionIds) {
+        List<Mission> missions = missionQueryRepository.findAllByIdsInFetchJoinStamp(missionIds);
+
+        MissionPolicy.validateExistAll(missions, missionIds);
+        missions.forEach(
+                mission -> {
+                    MissionPolicy.validateNotDeleted(mission);
+                    MissionPolicy.validateCompleted(mission);
+                });
+
+        return missions;
+    }
+
+    public void validateMissionBelongsToStamp(Long stampId, Mission mission) {
+        MissionPolicy.validateMissionBelongsToStamp(stampId, mission);
     }
 
     private void validateMissionIsActiveAndBelongsToStamp(Long stampId, Mission mission) {

--- a/src/main/java/com/ject/studytrip/mission/domain/error/DailyMissionErrorCode.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/error/DailyMissionErrorCode.java
@@ -1,0 +1,37 @@
+package com.ject.studytrip.mission.domain.error;
+
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DailyMissionErrorCode implements ErrorCode {
+    // 400
+    DAILY_MISSION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 데일리 미션입니다."),
+
+    // 403
+    DAILY_MISSION_NOT_BELONG_TO_DAILY_GOAL(
+            HttpStatus.FORBIDDEN, "해당 데일리 미션은 요청한 데일리 목표에 속하지 않습니다."),
+
+    // 404
+    DAILY_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 데일리 미션이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/error/MissionErrorCode.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/error/MissionErrorCode.java
@@ -12,6 +12,7 @@ public enum MissionErrorCode implements ErrorCode {
     MISSION_ORDER_IDS_NOT_MATCHED(HttpStatus.BAD_REQUEST, "요청한 미션 ID 목록이 기존 미션 목록과 일치하지 않습니다."),
     MISSION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "해당 미션은 이미 삭제되었습니다."),
     MISSION_ORDER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 미션 순서입니다."),
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 미션입니다."),
 
     // 403
     MISSION_NOT_BELONGS_TO_STAMP(HttpStatus.FORBIDDEN, "해당 미션은 요청한 스탬프에 속하지 않습니다."),

--- a/src/main/java/com/ject/studytrip/mission/domain/factory/DailyMissionFactory.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/factory/DailyMissionFactory.java
@@ -1,0 +1,14 @@
+package com.ject.studytrip.mission.domain.factory;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DailyMissionFactory {
+    public static DailyMission create(Mission mission, DailyGoal dailyGoal) {
+        return DailyMission.of(mission, dailyGoal);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/model/DailyMission.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/model/DailyMission.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.mission.domain.model;
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -26,5 +27,9 @@ public class DailyMission extends BaseTimeEntity {
 
     public static DailyMission of(Mission mission, DailyGoal dailyGoal) {
         return DailyMission.builder().mission(mission).dailyGoal(dailyGoal).build();
+    }
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/model/Mission.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/model/Mission.java
@@ -58,4 +58,8 @@ public class Mission extends BaseTimeEntity {
     public void updateDeletedAt() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void updateCompleted() {
+        this.completed = true;
+    }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/policy/DailyMissionPolicy.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/policy/DailyMissionPolicy.java
@@ -1,0 +1,27 @@
+package com.ject.studytrip.mission.domain.policy;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.mission.domain.error.DailyMissionErrorCode;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DailyMissionPolicy {
+    public static void validateExistAll(
+            List<DailyMission> foundDailyMissions, List<Long> requestedIds) {
+        boolean isEquals = foundDailyMissions.size() == requestedIds.size();
+        if (!isEquals) throw new CustomException(DailyMissionErrorCode.DAILY_MISSION_NOT_FOUND);
+    }
+
+    public static void validateBelongsToDailyGoal(DailyMission dailyMission, Long dailyGoalId) {
+        if (!dailyMission.getDailyGoal().getId().equals(dailyGoalId))
+            throw new CustomException(DailyMissionErrorCode.DAILY_MISSION_NOT_BELONG_TO_DAILY_GOAL);
+    }
+
+    public static void validateNotDeleted(DailyMission dailyMission) {
+        if (dailyMission.getDeletedAt() != null)
+            throw new CustomException(DailyMissionErrorCode.DAILY_MISSION_ALREADY_DELETED);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/policy/MissionPolicy.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/policy/MissionPolicy.java
@@ -53,4 +53,16 @@ public class MissionPolicy {
             throw new CustomException(MissionErrorCode.MISSION_ORDER_ALREADY_EXISTS);
         }
     }
+
+    public static void validateCompleted(Mission mission) {
+        if (mission.isCompleted())
+            throw new CustomException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
+    }
+
+    public static void validateExistAll(List<Mission> foundMissions, List<Long> requestedIds) {
+        boolean isEquals = foundMissions.size() == requestedIds.size();
+        if (!isEquals) {
+            throw new CustomException(MissionErrorCode.MISSION_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.mission.domain.repository;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import java.util.List;
+
+public interface DailyMissionQueryRepository {
+    List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId);
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionRepository.java
@@ -1,0 +1,12 @@
+package com.ject.studytrip.mission.domain.repository;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import java.util.List;
+
+public interface DailyMissionRepository {
+    DailyMission save(DailyMission dailyMission);
+
+    List<DailyMission> saveAll(List<DailyMission> dailyMissions);
+
+    List<DailyMission> findAllByIdIn(List<Long> ids);
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.mission.domain.repository;
+
+import com.ject.studytrip.mission.domain.model.Mission;
+import java.util.List;
+
+public interface MissionQueryRepository {
+    List<Mission> findAllByIdsInFetchJoinStamp(List<Long> ids);
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionJpaRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyMissionJpaRepository extends JpaRepository<DailyMission, Long> {
+    List<DailyMission> findAllByIdIn(List<Long> ids);
+
+    List<DailyMission> findAllByDailyGoalIdAndDeletedAtIsNull(Long dailyGoalId);
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionQueryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.QDailyMission;
+import com.ject.studytrip.mission.domain.model.QMission;
+import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QDailyMission dailyMission = QDailyMission.dailyMission;
+    private final QMission mission = QMission.mission;
+
+    @Override
+    public List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId) {
+        return queryFactory
+                .selectFrom(dailyMission)
+                .join(dailyMission.mission, mission)
+                .fetchJoin()
+                .where(dailyMission.dailyGoal.id.eq(dailyGoalId), dailyMission.deletedAt.isNull())
+                .fetch();
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/DailyMissionRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyMissionRepositoryAdapter implements DailyMissionRepository {
+    private final DailyMissionJpaRepository dailyMissionJpaRepository;
+
+    @Override
+    public DailyMission save(DailyMission dailyMission) {
+        return dailyMissionJpaRepository.save(dailyMission);
+    }
+
+    @Override
+    public List<DailyMission> saveAll(List<DailyMission> dailyMissions) {
+        return dailyMissionJpaRepository.saveAll(dailyMissions);
+    }
+
+    @Override
+    public List<DailyMission> findAllByIdIn(List<Long> ids) {
+        return dailyMissionJpaRepository.findAllByIdIn(ids);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/jpa/MissionQueryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.ject.studytrip.mission.infra.jpa;
+
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.model.QMission;
+import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
+import com.ject.studytrip.stamp.domain.model.QStamp;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionQueryRepositoryAdapter implements MissionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QMission mission = QMission.mission;
+    private final QStamp stamp = QStamp.stamp;
+
+    @Override
+    public List<Mission> findAllByIdsInFetchJoinStamp(List<Long> ids) {
+        return queryFactory
+                .selectFrom(mission)
+                .join(mission.stamp, stamp)
+                .fetchJoin()
+                .where(mission.id.in(ids))
+                .fetch();
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/application/dto/PomodoroInfo.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/dto/PomodoroInfo.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.pomodoro.application.dto;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+
+public record PomodoroInfo(Long pomodoroId, int focusDurationInMinute) {
+    public static PomodoroInfo from(Pomodoro pomodoro) {
+        return new PomodoroInfo(pomodoro.getId(), pomodoro.getFocusDurationInSeconds() / 60);
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
@@ -1,0 +1,40 @@
+package com.ject.studytrip.pomodoro.application.service;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
+import com.ject.studytrip.pomodoro.domain.factory.PomodoroFactory;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.pomodoro.domain.policy.PomodoroPolicy;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
+import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PomodoroService {
+    private final PomodoroRepository pomodoroRepository;
+
+    public Pomodoro createPomodoro(DailyGoal dailyGoal, CreatePomodoroRequest request) {
+        int focusDurationInSeconds = request.focusDurationInMinute() * 60;
+        Pomodoro pomodoro = PomodoroFactory.create(dailyGoal, focusDurationInSeconds, 1, 0);
+        return pomodoroRepository.save(pomodoro);
+    }
+
+    public void deletePomodoro(Pomodoro pomodoro) {
+        pomodoro.updateDeletedAt();
+    }
+
+    public Pomodoro getValidPomodoroByDailyGoal(Long dailyGoalId) {
+        Pomodoro pomodoro =
+                pomodoroRepository
+                        .findByDailyGoalId(dailyGoalId)
+                        .orElseThrow(
+                                () -> new CustomException(PomodoroErrorCode.POMODORO_NOT_FOUND));
+
+        PomodoroPolicy.validateNotDeleted(pomodoro);
+
+        return pomodoro;
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/error/PomodoroErrorCode.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/error/PomodoroErrorCode.java
@@ -1,0 +1,33 @@
+package com.ject.studytrip.pomodoro.domain.error;
+
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum PomodoroErrorCode implements ErrorCode {
+    // 400
+    POMODORO_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 뽀모도로입니다."),
+
+    // 404
+    POMODORO_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 뽀모도로 정보를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.pomodoro.domain.model;
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -39,5 +40,9 @@ public class Pomodoro extends BaseTimeEntity {
                 .breakDurationInSeconds(0)
                 .totalFocusTimeInSeconds(0)
                 .build();
+    }
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/policy/PomodoroPolicy.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/policy/PomodoroPolicy.java
@@ -1,0 +1,15 @@
+package com.ject.studytrip.pomodoro.domain.policy;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PomodoroPolicy {
+    public static void validateNotDeleted(Pomodoro pomodoro) {
+        if (pomodoro.getDeletedAt() != null)
+            throw new CustomException(PomodoroErrorCode.POMODORO_ALREADY_DELETED);
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroRepository.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroRepository.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.pomodoro.domain.repository;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import java.util.Optional;
+
+public interface PomodoroRepository {
+    Pomodoro save(Pomodoro pomodoro);
+
+    Optional<Pomodoro> findByDailyGoalId(Long dailyGoalId);
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/infra/jpa/PomodoroJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/infra/jpa/PomodoroJpaRepository.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.pomodoro.infra.jpa;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PomodoroJpaRepository extends JpaRepository<Pomodoro, Long> {
+
+    Optional<Pomodoro> findByDailyGoalId(Long dailyGoalId);
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/infra/jpa/PomodoroRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/infra/jpa/PomodoroRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.ject.studytrip.pomodoro.infra.jpa;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PomodoroRepositoryAdapter implements PomodoroRepository {
+    private final PomodoroJpaRepository pomodoroJpaRepository;
+
+    @Override
+    public Pomodoro save(Pomodoro pomodoro) {
+        return pomodoroJpaRepository.save(pomodoro);
+    }
+
+    @Override
+    public Optional<Pomodoro> findByDailyGoalId(Long dailyGoalId) {
+        return pomodoroJpaRepository.findByDailyGoalId(dailyGoalId);
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
@@ -1,0 +1,6 @@
+package com.ject.studytrip.pomodoro.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record CreatePomodoroRequest(
+        @Min(value = 1, message = "뽀모도로 최소 집중 시간은 1분입니다.") int focusDurationInMinute) {}

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
@@ -131,6 +131,16 @@ public class StampService {
         return stamp;
     }
 
+    public Stamp getFirstInCompleteStampForCourseTrip(Long tripId) {
+        return stampQueryRepository
+                .findFirstIncompleteStampByTripId(tripId)
+                .orElseThrow(() -> new CustomException(StampErrorCode.STAMP_NOT_FOUND));
+    }
+
+    public void validateStampBelongsToTrip(Long tripId, Stamp stamp) {
+        StampPolicy.validateStampBelongsToTrip(tripId, stamp);
+    }
+
     private void shiftStampOrdersAfterDeleted(Long tripId, int deletedStampOrder) {
         List<Stamp> affectedStamps =
                 stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedStampOrder);

--- a/src/main/java/com/ject/studytrip/stamp/domain/model/Stamp.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/model/Stamp.java
@@ -54,6 +54,10 @@ public class Stamp extends BaseTimeEntity {
         this.stampOrder = newOrder;
     }
 
+    public void updateCompleted() {
+        this.completed = true;
+    }
+
     public void updateDeletedAt() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
@@ -2,7 +2,10 @@ package com.ject.studytrip.stamp.domain.repository;
 
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import java.util.List;
+import java.util.Optional;
 
 public interface StampQueryRepository {
     List<Stamp> findStampsToShiftAfterOrder(Long tripId, int deletedOrder);
+
+    Optional<Stamp> findFirstIncompleteStampByTripId(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/jpa/StampQueryRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -24,5 +25,19 @@ public class StampQueryRepositoryAdapter implements StampQueryRepository {
                         stamp.deletedAt.isNull())
                 .orderBy(stamp.stampOrder.asc())
                 .fetch();
+    }
+
+    // 완료되지 않은 스탬프 중 가장 첫번째 스탬프 조회
+    @Override
+    public Optional<Stamp> findFirstIncompleteStampByTripId(Long tripId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(stamp)
+                        .where(
+                                stamp.trip.id.eq(tripId),
+                                stamp.completed.isFalse(),
+                                stamp.deletedAt.isNull())
+                        .orderBy(stamp.stampOrder.asc())
+                        .fetchFirst());
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalDetail.java
+++ b/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalDetail.java
@@ -1,0 +1,17 @@
+package com.ject.studytrip.trip.application.dto;
+
+import com.ject.studytrip.mission.application.dto.DailyMissionInfo;
+import com.ject.studytrip.pomodoro.application.dto.PomodoroInfo;
+import java.util.List;
+
+public record DailyGoalDetail(
+        DailyGoalInfo dailyGoalInfo,
+        PomodoroInfo pomodoroInfo,
+        List<DailyMissionInfo> dailyMissionInfos) {
+    public static DailyGoalDetail from(
+            DailyGoalInfo dailyGoalInfo,
+            PomodoroInfo pomodoroInfo,
+            List<DailyMissionInfo> dailyMissionInfos) {
+        return new DailyGoalDetail(dailyGoalInfo, pomodoroInfo, dailyMissionInfos);
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalInfo.java
+++ b/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalInfo.java
@@ -1,0 +1,16 @@
+package com.ject.studytrip.trip.application.dto;
+
+import com.ject.studytrip.global.util.DateUtil;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+
+public record DailyGoalInfo(
+        Long dailyGoalId, boolean completed, String createdAt, String updatedAt, String deletedAt) {
+    public static DailyGoalInfo from(DailyGoal dailyGoal) {
+        return new DailyGoalInfo(
+                dailyGoal.getId(),
+                dailyGoal.isCompleted(),
+                DateUtil.formatDateTime(dailyGoal.getCreatedAt()),
+                DateUtil.formatDateTime(dailyGoal.getUpdatedAt()),
+                DateUtil.formatDateTime(dailyGoal.getDeletedAt()));
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/application/facade/DailyGoalFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/DailyGoalFacade.java
@@ -1,0 +1,138 @@
+package com.ject.studytrip.trip.application.facade;
+
+import com.ject.studytrip.member.application.service.MemberService;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.mission.application.dto.DailyMissionInfo;
+import com.ject.studytrip.mission.application.service.DailyMissionService;
+import com.ject.studytrip.mission.application.service.MissionService;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.pomodoro.application.dto.PomodoroInfo;
+import com.ject.studytrip.pomodoro.application.service.PomodoroService;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.stamp.application.service.StampService;
+import com.ject.studytrip.trip.application.dto.DailyGoalDetail;
+import com.ject.studytrip.trip.application.dto.DailyGoalInfo;
+import com.ject.studytrip.trip.application.service.DailyGoalService;
+import com.ject.studytrip.trip.application.service.TripService;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.presentation.dto.request.CreateDailyGoalRequest;
+import com.ject.studytrip.trip.presentation.dto.request.UpdateDailyGoalRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DailyGoalFacade {
+    private final MemberService memberService;
+    private final TripService tripService;
+    private final StampService stampService;
+    private final MissionService missionService;
+    private final DailyGoalService dailyGoalService;
+    private final PomodoroService pomodoroService;
+    private final DailyMissionService dailyMissionService;
+
+    @Transactional
+    public DailyGoalInfo createDailyGoal(
+            Long memberId, Long tripId, CreateDailyGoalRequest request) {
+        Trip trip = getValidTripOwnedByMember(memberId, tripId);
+
+        DailyGoal dailyGoal = dailyGoalService.createDailyGoal(trip);
+
+        List<Mission> missions = getValidMissionsByTripCategory(trip, request.missionIds());
+        dailyMissionService.createDailyMissions(dailyGoal, missions);
+
+        pomodoroService.createPomodoro(dailyGoal, request.pomodoro());
+
+        return DailyGoalInfo.from(dailyGoal);
+    }
+
+    @Transactional
+    public void updateDailyGoal(
+            Long memberId, Long tripId, Long dailyGoalId, UpdateDailyGoalRequest request) {
+        Trip trip = getValidTripOwnedByMember(memberId, tripId);
+
+        DailyGoal dailyGoal = dailyGoalService.getValidDailyGoal(trip.getId(), dailyGoalId);
+
+        // 삭제할 데일리 미션이 있을 경우
+        if (request.deleteDailyMissionIds() != null && !request.deleteDailyMissionIds().isEmpty()) {
+            List<DailyMission> deleteDailyMissions =
+                    dailyMissionService.getValidDailyMissionsByIds(
+                            dailyGoal.getId(), request.deleteDailyMissionIds());
+            deleteDailyMissions.forEach(dailyMissionService::deleteDailyMission);
+        }
+
+        // 새로 추가할 미션이 있을 경우
+        if (request.addMissionIds() != null && !request.addMissionIds().isEmpty()) {
+            List<Mission> addMissions =
+                    getValidMissionsByTripCategory(trip, request.addMissionIds());
+            dailyMissionService.createDailyMissions(dailyGoal, addMissions);
+        }
+    }
+
+    @Transactional
+    public void deleteDailyGoal(Long memberId, Long tripId, Long dailyGoalId) {
+        Trip trip = getValidTripOwnedByMember(memberId, tripId);
+
+        DailyGoal dailyGoal = dailyGoalService.getValidDailyGoal(trip.getId(), dailyGoalId);
+
+        // 뽀모도로 삭제
+        Pomodoro pomodoro = pomodoroService.getValidPomodoroByDailyGoal(dailyGoal.getId());
+        pomodoroService.deletePomodoro(pomodoro);
+
+        // 데일리 미션 삭제
+        List<DailyMission> dailyMissions =
+                dailyMissionService.getDailyMissionsByDailyGoal(dailyGoal.getId());
+        for (DailyMission dailyMission : dailyMissions) {
+            dailyMissionService.deleteDailyMission(dailyMission);
+        }
+
+        // 데일리 목표 삭제
+        dailyGoalService.deleteDailyGoal(dailyGoal);
+    }
+
+    public DailyGoalDetail getDailyGoal(Long memberId, Long tripId, Long dailyGoalId) {
+        Trip trip = getValidTripOwnedByMember(memberId, tripId);
+
+        DailyGoal dailyGoal = dailyGoalService.getValidDailyGoal(trip.getId(), dailyGoalId);
+
+        Pomodoro pomodoro = pomodoroService.getValidPomodoroByDailyGoal(dailyGoal.getId());
+        List<DailyMission> dailyMissions =
+                dailyMissionService.getDailyMissionsByDailyGoal(dailyGoal.getId());
+
+        return DailyGoalDetail.from(
+                DailyGoalInfo.from(dailyGoal),
+                PomodoroInfo.from(pomodoro),
+                dailyMissions.stream().map(DailyMissionInfo::from).toList());
+    }
+
+    private Trip getValidTripOwnedByMember(Long memberId, Long tripId) {
+        Member member = memberService.getMember(memberId);
+
+        return tripService.getValidTrip(member.getId(), tripId);
+    }
+
+    private List<Mission> getValidMissionsByTripCategory(Trip trip, List<Long> missionIds) {
+        List<Mission> missions = missionService.getValidMissionsWithStamp(missionIds);
+
+        for (Mission mission : missions) {
+            stampService.validateStampBelongsToTrip(trip.getId(), mission.getStamp());
+        }
+
+        // 코스형 여행일 경우, 현재 진행중인 스탬프를 조회하고 요청한 미션들이 해당 스탬프에 속해 있는 미션들인지 검증
+        if (trip.getCategory() == TripCategory.COURSE) {
+            Long currentStampId =
+                    stampService.getFirstInCompleteStampForCourseTrip(trip.getId()).getId();
+
+            for (Mission mission : missions) {
+                missionService.validateMissionBelongsToStamp(currentStampId, mission);
+            }
+        }
+
+        return missions;
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalService.java
@@ -1,0 +1,39 @@
+package com.ject.studytrip.trip.application.service;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.trip.domain.error.DailyGoalErrorCode;
+import com.ject.studytrip.trip.domain.factory.DailyGoalFactory;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.policy.DailyGoalPolicy;
+import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DailyGoalService {
+    public final DailyGoalRepository dailyGoalRepository;
+
+    public DailyGoal createDailyGoal(Trip trip) {
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+        return dailyGoalRepository.save(dailyGoal);
+    }
+
+    public void deleteDailyGoal(DailyGoal dailyGoal) {
+        dailyGoal.updateDeletedAt();
+    }
+
+    public DailyGoal getValidDailyGoal(Long tripId, Long dailyGoalId) {
+        DailyGoal dailyGoal =
+                dailyGoalRepository
+                        .findById(dailyGoalId)
+                        .orElseThrow(
+                                () -> new CustomException(DailyGoalErrorCode.DAILY_GOAL_NOT_FOUND));
+
+        DailyGoalPolicy.validateBelongsToTrip(dailyGoal, tripId);
+        DailyGoalPolicy.validateNotDeleted(dailyGoal);
+
+        return dailyGoal;
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/error/DailyGoalErrorCode.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/error/DailyGoalErrorCode.java
@@ -1,0 +1,36 @@
+package com.ject.studytrip.trip.domain.error;
+
+import com.ject.studytrip.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DailyGoalErrorCode implements ErrorCode {
+    // 400
+    DAILY_GOAL_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 데일리 목표입니다."),
+
+    // 403
+    DAILY_GOAL_NOT_BELONG_TO_TRIP(HttpStatus.FORBIDDEN, "해당 데일리 목표는 요청한 여행에 속하지 않습니다."),
+
+    //  404
+    DAILY_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 데일리 목표가 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/factory/DailyGoalFactory.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/factory/DailyGoalFactory.java
@@ -1,0 +1,13 @@
+package com.ject.studytrip.trip.domain.factory;
+
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DailyGoalFactory {
+    public static DailyGoal create(Trip trip) {
+        return DailyGoal.of(trip);
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
@@ -2,6 +2,7 @@ package com.ject.studytrip.trip.domain.model;
 
 import com.ject.studytrip.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -23,5 +24,9 @@ public class DailyGoal extends BaseTimeEntity {
 
     public static DailyGoal of(Trip trip) {
         return DailyGoal.builder().trip(trip).completed(false).build();
+    }
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/policy/DailyGoalPolicy.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/policy/DailyGoalPolicy.java
@@ -1,0 +1,20 @@
+package com.ject.studytrip.trip.domain.policy;
+
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.trip.domain.error.DailyGoalErrorCode;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DailyGoalPolicy {
+    public static void validateBelongsToTrip(DailyGoal dailyGoal, Long tripId) {
+        if (!dailyGoal.getTrip().getId().equals(tripId))
+            throw new CustomException(DailyGoalErrorCode.DAILY_GOAL_NOT_BELONG_TO_TRIP);
+    }
+
+    public static void validateNotDeleted(DailyGoal dailyGoal) {
+        if (dailyGoal.getDeletedAt() != null)
+            throw new CustomException(DailyGoalErrorCode.DAILY_GOAL_ALREADY_DELETED);
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.trip.domain.repository;
+
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import java.util.Optional;
+
+public interface DailyGoalRepository {
+
+    DailyGoal save(DailyGoal dailyGoal);
+
+    Optional<DailyGoal> findById(Long id);
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/jpa/DailyGoalJpaRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/jpa/DailyGoalJpaRepository.java
@@ -1,0 +1,6 @@
+package com.ject.studytrip.trip.infra.jpa;
+
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyGoalJpaRepository extends JpaRepository<DailyGoal, Long> {}

--- a/src/main/java/com/ject/studytrip/trip/infra/jpa/DailyGoalRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/jpa/DailyGoalRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.ject.studytrip.trip.infra.jpa;
+
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyGoalRepositoryAdapter implements DailyGoalRepository {
+    private final DailyGoalJpaRepository dailyGoalJpaRepository;
+
+    @Override
+    public DailyGoal save(DailyGoal dailyGoal) {
+        return dailyGoalJpaRepository.save(dailyGoal);
+    }
+
+    @Override
+    public Optional<DailyGoal> findById(Long id) {
+        return dailyGoalJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/presentation/controller/DailyGoalController.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/controller/DailyGoalController.java
@@ -1,0 +1,87 @@
+package com.ject.studytrip.trip.presentation.controller;
+
+import com.ject.studytrip.global.common.response.StandardResponse;
+import com.ject.studytrip.trip.application.dto.DailyGoalDetail;
+import com.ject.studytrip.trip.application.dto.DailyGoalInfo;
+import com.ject.studytrip.trip.application.facade.DailyGoalFacade;
+import com.ject.studytrip.trip.presentation.dto.request.CreateDailyGoalRequest;
+import com.ject.studytrip.trip.presentation.dto.request.UpdateDailyGoalRequest;
+import com.ject.studytrip.trip.presentation.dto.response.CreateDailyGoalResponse;
+import com.ject.studytrip.trip.presentation.dto.response.LoadDailyGoalDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "DailyGoal", description = "데일리 목표 API")
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class DailyGoalController {
+    private final DailyGoalFacade dailyGoalFacade;
+
+    @Operation(summary = "데일리 목표 생성", description = "데일리 목표를 생성하는 API 입니다.")
+    @PostMapping("/api/trips/{tripId}/daily-goals")
+    public ResponseEntity<StandardResponse> createDailyGoal(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @RequestBody @Valid CreateDailyGoalRequest request) {
+        DailyGoalInfo result =
+                dailyGoalFacade.createDailyGoal(Long.valueOf(memberId), tripId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        StandardResponse.success(
+                                HttpStatus.CREATED.value(), CreateDailyGoalResponse.of(result)));
+    }
+
+    @Operation(summary = "데일리 목표 수정", description = "데일리 목표를 수정하는 API 입니다.")
+    @PatchMapping("/api/trips/{tripId}/daily-goals/{dailyGoalId}")
+    public ResponseEntity<StandardResponse> updateDailyGoal(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "데일리 목표 ID는 필수 요청 파라미터입니다.") Long dailyGoalId,
+            @RequestBody UpdateDailyGoalRequest request) {
+        dailyGoalFacade.updateDailyGoal(Long.valueOf(memberId), tripId, dailyGoalId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @Operation(summary = "데일리 목표 삭제", description = "데일리 목표를 삭제하는 API 입니다.")
+    @DeleteMapping("/api/trips/{tripId}/daily-goals/{dailyGoalId}")
+    public ResponseEntity<StandardResponse> deleteDailyGoal(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "데일리 목표 ID는 필수 요청 파라미터입니다.") Long dailyGoalId) {
+        dailyGoalFacade.deleteDailyGoal(Long.valueOf(memberId), tripId, dailyGoalId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @Operation(summary = "특정 데일리 목표 조회", description = "특정 데일리 목표를 조회하는 API 입니다.")
+    @GetMapping("/api/trips/{tripId}/daily-goals/{dailyGoalId}")
+    public ResponseEntity<StandardResponse> loadDailyGoal(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
+            @PathVariable @NotNull(message = "데일리 목표 ID는 필수 요청 파라미터입니다.") Long dailyGoalId) {
+        DailyGoalDetail result =
+                dailyGoalFacade.getDailyGoal(Long.valueOf(memberId), tripId, dailyGoalId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        StandardResponse.success(
+                                HttpStatus.OK.value(),
+                                LoadDailyGoalDetailResponse.of(
+                                        result.dailyGoalInfo(),
+                                        result.pomodoroInfo(),
+                                        result.dailyMissionInfos())));
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/request/CreateDailyGoalRequest.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/request/CreateDailyGoalRequest.java
@@ -1,0 +1,14 @@
+package com.ject.studytrip.trip.presentation.dto.request;
+
+import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record CreateDailyGoalRequest(
+        @Schema(name = "뽀모도로") @Valid @NotNull(message = "뽀모도로 정보는 필수 요청 값입니다.")
+                CreatePomodoroRequest pomodoro,
+        @Schema(name = "수행할 미션 ID 목록") @NotEmpty(message = "수행할 미션 목록은 필수 요청 값입니다.")
+                List<Long> missionIds) {}

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/request/UpdateDailyGoalRequest.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/request/UpdateDailyGoalRequest.java
@@ -1,0 +1,8 @@
+package com.ject.studytrip.trip.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record UpdateDailyGoalRequest(
+        @Schema(name = "삭제할 데일리 미션 ID 목록") List<Long> deleteDailyMissionIds,
+        @Schema(name = "추가할 미션 ID 목록") List<Long> addMissionIds) {}

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/CreateDailyGoalResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/CreateDailyGoalResponse.java
@@ -1,0 +1,10 @@
+package com.ject.studytrip.trip.presentation.dto.response;
+
+import com.ject.studytrip.trip.application.dto.DailyGoalInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateDailyGoalResponse(@Schema(name = "데일리 목표 ID") Long dailyGoalId) {
+    public static CreateDailyGoalResponse of(DailyGoalInfo dailyGoalInfo) {
+        return new CreateDailyGoalResponse(dailyGoalInfo.dailyGoalId());
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
@@ -1,0 +1,45 @@
+package com.ject.studytrip.trip.presentation.dto.response;
+
+import com.ject.studytrip.mission.application.dto.DailyMissionInfo;
+import com.ject.studytrip.pomodoro.application.dto.PomodoroInfo;
+import com.ject.studytrip.trip.application.dto.DailyGoalInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record LoadDailyGoalDetailResponse(
+        @Schema(name = "데일리 목표 ID") Long dailyGoalId,
+        @Schema(name = "데일리 목표 완료 여부") boolean completed,
+        @Schema(name = "뽀모도로 정보") DailyGoalPomodoroResponse pomodoro,
+        @Schema(name = "수행할 데일리 미션 목록") List<DailyGoalMissionResponse> dailyMissions) {
+
+    public static LoadDailyGoalDetailResponse of(
+            DailyGoalInfo dailyGoalInfo,
+            PomodoroInfo pomodoroInfo,
+            List<DailyMissionInfo> dailyMissionInfos) {
+        return new LoadDailyGoalDetailResponse(
+                dailyGoalInfo.dailyGoalId(),
+                dailyGoalInfo.completed(),
+                DailyGoalPomodoroResponse.of(pomodoroInfo),
+                dailyMissionInfos.stream().map(DailyGoalMissionResponse::of).toList());
+    }
+
+    public record DailyGoalPomodoroResponse(
+            @Schema(name = "뽀모도로 ID") Long pomodoroId,
+            @Schema(name = "뽀모도로 집중 시간(분)") int focusDurationInMinute) {
+        public static DailyGoalPomodoroResponse of(PomodoroInfo info) {
+            return new DailyGoalPomodoroResponse(info.pomodoroId(), info.focusDurationInMinute());
+        }
+    }
+
+    public record DailyGoalMissionResponse(
+            @Schema(name = "데일리 미션 ID") Long dailyMissionId,
+            @Schema(name = "미션 이름") String missionName,
+            @Schema(name = "미션 메모") String missionMemo) {
+        public static DailyGoalMissionResponse of(DailyMissionInfo info) {
+            return new DailyGoalMissionResponse(
+                    info.dailyMissionId(),
+                    info.missionInfo().missionName(),
+                    info.missionInfo().missionMemo());
+        }
+    }
+}

--- a/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionServiceTest.java
@@ -1,0 +1,180 @@
+package com.ject.studytrip.mission.application.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ject.studytrip.BaseUnitTest;
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.fixture.MemberFixture;
+import com.ject.studytrip.mission.domain.error.DailyMissionErrorCode;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
+import com.ject.studytrip.mission.fixture.DailyMissionFixture;
+import com.ject.studytrip.mission.fixture.MissionFixture;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.fixture.StampFixture;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.fixture.DailyGoalFixture;
+import com.ject.studytrip.trip.fixture.TripFixture;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("DailyMissionService 단위 테스트")
+public class DailyMissionServiceTest extends BaseUnitTest {
+
+    @InjectMocks private DailyMissionService dailyMissionService;
+    @Mock private DailyMissionRepository dailyMissionRepository;
+    @Mock private DailyMissionQueryRepository dailyMissionQueryRepository;
+
+    private DailyGoal dailyGoal;
+    private Mission mission;
+    private DailyMission dailyMission;
+
+    @BeforeEach
+    void setUp() {
+        Member member = MemberFixture.createMemberFromKakaoWithId(1L);
+        Trip trip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
+        Stamp stamp = StampFixture.createStampWithId(1L, trip, 1);
+        mission = MissionFixture.createMissionWithId(1L, stamp, 1);
+        dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, trip);
+        dailyMission = DailyMissionFixture.createDailyMissionWithId(1L, mission, dailyGoal);
+    }
+
+    @Nested
+    @DisplayName("데일리 미션을 생성한다")
+    class CreateDailyMission {
+
+        @Test
+        @DisplayName("미션 리스트로 데일리 미션을 생성하여 저장하고 반환한다")
+        void shouldCreateDailyMissions() {
+            // given
+            List<Mission> missions = List.of(mission);
+            given(dailyMissionRepository.saveAll(any())).willReturn(List.of(dailyMission));
+
+            // when
+            List<DailyMission> result =
+                    dailyMissionService.createDailyMissions(dailyGoal, missions);
+
+            // then
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getDailyGoal().getId()).isEqualTo(dailyGoal.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 미션을 삭제한다")
+    class DeleteDailyMission {
+
+        @Test
+        @DisplayName("삭제 시 deletedAt을 현재 시각으로 설정한다")
+        void shouldDeleteDailyMission() {
+            // when
+            dailyMissionService.deleteDailyMission(dailyMission);
+
+            // then
+            assertThat(dailyMission.getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 미션 목록 조회")
+    class ListDailyMissions {
+
+        @Test
+        @DisplayName("ID 리스트로 유효한 데일리 미션을 조회해 반환한다")
+        void shouldGetDailyMissionsByIds() {
+            // given
+            List<Long> ids = List.of(dailyMission.getId());
+            List<DailyMission> dailyMissions = List.of(dailyMission);
+            given(dailyMissionRepository.findAllByIdIn(ids)).willReturn(dailyMissions);
+
+            // when
+            List<DailyMission> result =
+                    dailyMissionService.getValidDailyMissionsByIds(dailyGoal.getId(), ids);
+
+            // then
+            assertThat(result.isEmpty()).isFalse();
+        }
+
+        @Test
+        @DisplayName("요청한 ID 개수와 조회된 데일리 미션 개수가 다르면 예외가 발생한다")
+        void shouldThrowExceptionWhenSomeDailyMissionsDoNotExist() {
+            // given
+            List<Long> ids = List.of(1L, 2L);
+            given(dailyMissionRepository.findAllByIdIn(ids)).willReturn(List.of(dailyMission));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    dailyMissionService.getValidDailyMissionsByIds(
+                                            dailyGoal.getId(), ids))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(DailyMissionErrorCode.DAILY_MISSION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("데일리 미션이 요청한 데일리 목표에 속하지 않으면 예외를 던진다")
+        void shouldThrowExceptionWhenDailyMissionDoesNotBelongToDailyGoal() {
+            // given
+            DailyGoal otherGoal = DailyGoalFixture.createDailyGoalWithId(999L, dailyGoal.getTrip());
+            List<Long> ids = List.of(dailyMission.getId());
+            given(dailyMissionRepository.findAllByIdIn(ids)).willReturn(List.of(dailyMission));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    dailyMissionService.getValidDailyMissionsByIds(
+                                            otherGoal.getId(), ids))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(
+                            DailyMissionErrorCode.DAILY_MISSION_NOT_BELONG_TO_DAILY_GOAL
+                                    .getMessage());
+        }
+
+        @Test
+        @DisplayName("데일리 미션이 이미 삭제된 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenDailyMissionIsDeleted() {
+            // given
+            dailyMission.updateDeletedAt(); // deleted
+            given(dailyMissionRepository.findAllByIdIn(List.of(1L)))
+                    .willReturn(List.of(dailyMission));
+
+            // when & then
+            Assertions.assertThatThrownBy(
+                            () ->
+                                    dailyMissionService.getValidDailyMissionsByIds(
+                                            dailyGoal.getId(), List.of(dailyMission.getId())))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(DailyMissionErrorCode.DAILY_MISSION_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("데일리 목표 ID로 데일리 미션 목록을 반환한다")
+        void shouldGetDailyMissionsByDailyGoalId() {
+            // given
+            Long goalId = dailyGoal.getId();
+            List<DailyMission> missions = List.of(dailyMission);
+            given(dailyMissionQueryRepository.findAllByDailyGoalIdFetchJoinMission(goalId))
+                    .willReturn(missions);
+
+            // when
+            List<DailyMission> result = dailyMissionService.getDailyMissionsByDailyGoal(goalId);
+
+            // then
+            assertThat(result.isEmpty()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/ject/studytrip/mission/application/service/MissionServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/MissionServiceTest.java
@@ -11,6 +11,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.mission.domain.error.MissionErrorCode;
 import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
 import com.ject.studytrip.mission.domain.repository.MissionRepository;
 import com.ject.studytrip.mission.fixture.CreateMissionRequestFixture;
 import com.ject.studytrip.mission.fixture.MissionFixture;
@@ -41,7 +42,10 @@ class MissionServiceTest extends BaseUnitTest {
 
     @InjectMocks private MissionService missionService;
     @Mock private MissionRepository missionRepository;
+    @Mock private MissionQueryRepository missionQueryRepository;
 
+    private Trip courseTrip;
+    private Trip exploreTrip;
     private Stamp courseStamp;
     private Stamp exploreStamp;
     private Mission courseMission;
@@ -51,8 +55,8 @@ class MissionServiceTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         Member member = MemberFixture.createMemberFromKakao();
-        Trip courseTrip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
-        Trip exploreTrip = TripFixture.createTripWithId(2L, member, TripCategory.EXPLORE);
+        courseTrip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
+        exploreTrip = TripFixture.createTripWithId(2L, member, TripCategory.EXPLORE);
         courseStamp = StampFixture.createStampWithId(1L, courseTrip, 1);
         exploreStamp = StampFixture.createStampWithId(2L, exploreTrip, 0);
         courseMission = MissionFixture.createMissionWithId(1L, courseStamp, 1);
@@ -453,6 +457,63 @@ class MissionServiceTest extends BaseUnitTest {
 
             // then
             assertThat(result).isEqualTo(exploreMission1);
+        }
+
+        @Test
+        @DisplayName("유효한 미션 ID들로 요청 시 검증을 통과하고 미션 리스트를 반환한다")
+        void shouldReturnValidMissions() {
+            // given
+            List<Long> missionIds = List.of(courseMission.getId());
+            given(missionQueryRepository.findAllByIdsInFetchJoinStamp(missionIds))
+                    .willReturn(List.of(courseMission));
+
+            // when
+            List<Mission> result = missionService.getValidMissionsWithStamp(missionIds);
+
+            // then
+            assertThat(result).containsExactly(courseMission);
+        }
+
+        @Test
+        @DisplayName("요청한 ID 개수와 조회된 미션 개수가 다르면 예외가 발생한다")
+        void shouldThrowExceptionWhenSomeMissionsDoNotExist() {
+            // given
+            List<Long> missionIds = List.of(1L, 2L);
+            given(missionQueryRepository.findAllByIdsInFetchJoinStamp(missionIds))
+                    .willReturn(List.of(courseMission));
+
+            // when & then
+            assertThatThrownBy(() -> missionService.getValidMissionsWithStamp(missionIds))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MissionErrorCode.MISSION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 미션이 포함되어 있을 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenAnyMissionIsDeleted() {
+            // given
+            courseMission.updateDeletedAt(); // deleted
+            given(missionQueryRepository.findAllByIdsInFetchJoinStamp(any()))
+                    .willReturn(List.of(courseMission));
+
+            // when & then
+            assertThatThrownBy(() -> missionService.getValidMissionsWithStamp(List.of(1L)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MissionErrorCode.MISSION_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 완료된 미션이 포함되어 있을 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenAnyMissionIsCompleted() {
+            // given
+            courseMission.updateCompleted();
+            given(missionQueryRepository.findAllByIdsInFetchJoinStamp(any()))
+                    .willReturn(List.of(courseMission));
+
+            // when & then
+            assertThatThrownBy(() -> missionService.getValidMissionsWithStamp(List.of(1L)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MissionErrorCode.MISSION_ALREADY_COMPLETED.getMessage());
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/mission/fixture/DailyMissionFixture.java
+++ b/src/test/java/com/ject/studytrip/mission/fixture/DailyMissionFixture.java
@@ -1,0 +1,22 @@
+package com.ject.studytrip.mission.fixture;
+
+import com.ject.studytrip.mission.domain.factory.DailyMissionFactory;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DailyMissionFixture {
+
+    public static DailyMission createDailyMission(Mission mission, DailyGoal dailyGoal) {
+        return DailyMissionFactory.create(mission, dailyGoal);
+    }
+
+    public static DailyMission createDailyMissionWithId(
+            Long id, Mission mission, DailyGoal dailyGoal) {
+        DailyMission dailyMission = DailyMissionFactory.create(mission, dailyGoal);
+        ReflectionTestUtils.setField(dailyMission, "id", id);
+
+        return dailyMission;
+    }
+}

--- a/src/test/java/com/ject/studytrip/mission/helper/DailyMissionTestHelper.java
+++ b/src/test/java/com/ject/studytrip/mission/helper/DailyMissionTestHelper.java
@@ -1,0 +1,20 @@
+package com.ject.studytrip.mission.helper;
+
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
+import com.ject.studytrip.mission.fixture.DailyMissionFixture;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyMissionTestHelper {
+
+    @Autowired private DailyMissionRepository dailyMissionRepository;
+
+    public DailyMission saveDailyMission(Mission mission, DailyGoal dailyGoal) {
+        DailyMission dailyMission = DailyMissionFixture.createDailyMission(mission, dailyGoal);
+        return dailyMissionRepository.save(dailyMission);
+    }
+}

--- a/src/test/java/com/ject/studytrip/mission/helper/MissionTestHelper.java
+++ b/src/test/java/com/ject/studytrip/mission/helper/MissionTestHelper.java
@@ -23,4 +23,11 @@ public class MissionTestHelper {
 
         return missionRepository.save(mission);
     }
+
+    public Mission saveCompletedMission(Stamp stamp, int order) {
+        Mission mission = MissionFixture.createMission(stamp, order);
+        mission.updateCompleted();
+
+        return missionRepository.save(mission);
+    }
 }

--- a/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
@@ -1,0 +1,128 @@
+package com.ject.studytrip.pomodoro.application.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ject.studytrip.BaseUnitTest;
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.fixture.MemberFixture;
+import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
+import com.ject.studytrip.pomodoro.fixture.PomodoroFixture;
+import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.fixture.DailyGoalFixture;
+import com.ject.studytrip.trip.fixture.TripFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("PomodoroService 단위 테스트")
+public class PomodoroServiceTest extends BaseUnitTest {
+
+    @InjectMocks private PomodoroService pomodoroService;
+    @Mock private PomodoroRepository pomodoroRepository;
+
+    private DailyGoal dailyGoal;
+    private Pomodoro pomodoro;
+
+    @BeforeEach
+    void setUp() {
+        Member member = MemberFixture.createMemberFromKakaoWithId(1L);
+        Trip trip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
+        dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, trip);
+        pomodoro = PomodoroFixture.createPomodoroWithId(1L, dailyGoal);
+    }
+
+    @Nested
+    @DisplayName("뽀모도로를 생성한다")
+    class createPomodoro {
+
+        @Test
+        @DisplayName("뽀모도로를 생성해 저장하고 반환한다")
+        void shouldCreateAndReturnPomodoro() {
+            // given
+            CreatePomodoroRequest request = new CreatePomodoroRequest(30);
+            given(pomodoroRepository.save(any())).willReturn(pomodoro);
+
+            // when
+            Pomodoro result = pomodoroService.createPomodoro(dailyGoal, request);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getFocusDurationInSeconds()).isEqualTo(30 * 60);
+        }
+    }
+
+    @Nested
+    @DisplayName("뽀모도로를 삭제한다")
+    class deletePomodoro {
+
+        @Test
+        @DisplayName("deletedAt 필드를 설정해 삭제 처리한다")
+        void shouldSoftDeletePomodoro() {
+            // when
+            pomodoroService.deletePomodoro(pomodoro);
+
+            // then
+            assertThat(pomodoro.getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("뽀모도로를 조회한다")
+    class getPomodoro {
+
+        @Test
+        @DisplayName("데일리 목표 ID로 뽀모도로를 조회해 반환한다")
+        void shouldReturnPomodoroByDailyGoalId() {
+            // given
+            given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
+                    .willReturn(Optional.of(pomodoro));
+
+            // when
+            Pomodoro result = pomodoroService.getValidPomodoroByDailyGoal(dailyGoal.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getDailyGoal().getId()).isEqualTo(dailyGoal.getId());
+        }
+
+        @Test
+        @DisplayName("뽀모도로가 존재하지 않으면 예외가 발생한다")
+        void shouldThrowExceptionIfPomodoroNotFound() {
+            // given
+            given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> pomodoroService.getValidPomodoroByDailyGoal(dailyGoal.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PomodoroErrorCode.POMODORO_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 뽀모도로일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenDeletedPomodoro() {
+            // given
+            pomodoro.updateDeletedAt();
+            given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
+                    .willReturn(Optional.of(pomodoro));
+
+            // when & then
+            assertThatThrownBy(() -> pomodoroService.getValidPomodoroByDailyGoal(dailyGoal.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PomodoroErrorCode.POMODORO_ALREADY_DELETED.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/ject/studytrip/pomodoro/fixture/PomodoroFixture.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/fixture/PomodoroFixture.java
@@ -1,0 +1,26 @@
+package com.ject.studytrip.pomodoro.fixture;
+
+import com.ject.studytrip.pomodoro.domain.factory.PomodoroFactory;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PomodoroFixture {
+    private static final int FOCUS_DURATION_SECONDS = 30 * 60;
+    private static final int FOCUS_COUNT = 1;
+    private static final int BREAK_DURATION_SECONDS = 0;
+
+    public static Pomodoro createPomodoro(DailyGoal dailyGoal) {
+        return PomodoroFactory.create(
+                dailyGoal, FOCUS_DURATION_SECONDS, FOCUS_COUNT, BREAK_DURATION_SECONDS);
+    }
+
+    public static Pomodoro createPomodoroWithId(Long id, DailyGoal dailyGoal) {
+        Pomodoro pomodoro =
+                PomodoroFactory.create(
+                        dailyGoal, FOCUS_DURATION_SECONDS, FOCUS_COUNT, BREAK_DURATION_SECONDS);
+        ReflectionTestUtils.setField(pomodoro, "id", id);
+
+        return pomodoro;
+    }
+}

--- a/src/test/java/com/ject/studytrip/pomodoro/helper/PomodoroTestHelper.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/helper/PomodoroTestHelper.java
@@ -1,0 +1,25 @@
+package com.ject.studytrip.pomodoro.helper;
+
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
+import com.ject.studytrip.pomodoro.fixture.PomodoroFixture;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PomodoroTestHelper {
+
+    @Autowired private PomodoroRepository pomodoroRepository;
+
+    public Pomodoro savePomodoro(DailyGoal dailyGoal) {
+        return pomodoroRepository.save(PomodoroFixture.createPomodoro(dailyGoal));
+    }
+
+    public Pomodoro saveDeletedPomodoro(DailyGoal dailyGoal) {
+        Pomodoro pomodoro = pomodoroRepository.save(PomodoroFixture.createPomodoro(dailyGoal));
+        pomodoro.updateDeletedAt();
+
+        return pomodoro;
+    }
+}

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampServiceTest.java
@@ -558,5 +558,36 @@ public class StampServiceTest extends BaseUnitTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(StampErrorCode.STAMP_ALREADY_DELETED.getMessage());
         }
+
+        @Test
+        @DisplayName("코스형 여행 ID로 현재 진행중인 스탬프를 조회하고 반한환다")
+        void shouldReturnFirstIncompleteStampForCourseTrip() {
+            // given
+            given(stampQueryRepository.findFirstIncompleteStampByTripId(any()))
+                    .willReturn(Optional.ofNullable(courseStamp1));
+
+            // when
+            Stamp stamp = stampService.getFirstInCompleteStampForCourseTrip(courseTrip.getId());
+
+            // then
+            assertThat(stamp.getId()).isEqualTo(courseStamp1.getId());
+            assertThat(stamp.isCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("코스형 여행의 현재 진행중인 스탬프가 존재하지 않으면 예외가 발생한다")
+        void shouldThrowExceptionWhenNoIncompleteStampExistsForCourseTrip() {
+            // given
+            given(stampQueryRepository.findFirstIncompleteStampByTripId(any()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    stampService.getFirstInCompleteStampForCourseTrip(
+                                            courseTrip.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(StampErrorCode.STAMP_NOT_FOUND.getMessage());
+        }
     }
 }

--- a/src/test/java/com/ject/studytrip/stamp/helper/StampTestHelper.java
+++ b/src/test/java/com/ject/studytrip/stamp/helper/StampTestHelper.java
@@ -22,4 +22,11 @@ public class StampTestHelper {
 
         return stampRepository.save(stamp);
     }
+
+    public Stamp saveCompletedStamp(Trip trip, int order) {
+        Stamp stamp = StampFixture.createStamp(trip, order);
+        stamp.updateCompleted();
+
+        return stampRepository.save(stamp);
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalServiceTest.java
@@ -1,0 +1,140 @@
+package com.ject.studytrip.trip.application.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ject.studytrip.BaseUnitTest;
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.fixture.MemberFixture;
+import com.ject.studytrip.trip.domain.error.DailyGoalErrorCode;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
+import com.ject.studytrip.trip.fixture.DailyGoalFixture;
+import com.ject.studytrip.trip.fixture.TripFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("DailyGoalService 단위 테스트")
+public class DailyGoalServiceTest extends BaseUnitTest {
+
+    @InjectMocks private DailyGoalService dailyGoalService;
+    @Mock private DailyGoalRepository dailyGoalRepository;
+
+    private Member member;
+    private Trip trip;
+    private DailyGoal dailyGoal;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMemberFromKakaoWithId(1L);
+        trip = TripFixture.createTripWithId(1L, member, TripCategory.COURSE);
+        dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, trip);
+    }
+
+    @Nested
+    @DisplayName("데일리 목표를 생성한다")
+    class CreateDailyGoal {
+
+        @Test
+        @DisplayName("여행에 속한 데일리 목표를 생성하고 저장된 값을 반환한다")
+        void shouldCreateAndSaveDailyGoal() {
+            // given
+            given(dailyGoalRepository.save(any())).willReturn(dailyGoal);
+
+            // when
+            DailyGoal result = dailyGoalService.createDailyGoal(trip);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getTrip().getId()).isEqualTo(trip.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 목표를 삭제한다")
+    class DeleteDailyGoal {
+
+        @Test
+        @DisplayName("deletedAt을 현재 시간으로 설정한다")
+        void shouldSoftDeleteDailyGoal() {
+            // when
+            dailyGoalService.deleteDailyGoal(dailyGoal);
+
+            // then
+            assertThat(dailyGoal.getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 목표를 조회한다")
+    class GetDailyGoal {
+
+        @Test
+        @DisplayName("ID로 조회된 데일리 목표가 trip에 속하고 삭제되지 않았다면 반환한다")
+        void shouldReturnValidDailyGoal() {
+            // given
+            given(dailyGoalRepository.findById(dailyGoal.getId()))
+                    .willReturn(Optional.of(dailyGoal));
+
+            // when
+            DailyGoal result = dailyGoalService.getValidDailyGoal(trip.getId(), dailyGoal.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(dailyGoal.getId());
+        }
+
+        @Test
+        @DisplayName("데일리 목표가 존재하지 않으면 예외가 발생한다")
+        void shouldThrowExceptionWhenDailyGoalNotFound() {
+            // given
+            given(dailyGoalRepository.findById(any())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> dailyGoalService.getValidDailyGoal(trip.getId(), 999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(DailyGoalErrorCode.DAILY_GOAL_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("다른 여행에 속한 데일리 목표일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenNotBelongToTrip() {
+            // given
+            Trip otherTrip = TripFixture.createTripWithId(999L, member, TripCategory.COURSE);
+            given(dailyGoalRepository.findById(dailyGoal.getId()))
+                    .willReturn(Optional.of(dailyGoal));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    dailyGoalService.getValidDailyGoal(
+                                            otherTrip.getId(), dailyGoal.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(DailyGoalErrorCode.DAILY_GOAL_NOT_BELONG_TO_TRIP.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 데일리 목표일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenDeletedDailyGoal() {
+            // given
+            DailyGoal deleted = DailyGoalFixture.createDeletedDailyGoal(trip);
+            given(dailyGoalRepository.findById(deleted.getId())).willReturn(Optional.of(deleted));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> dailyGoalService.getValidDailyGoal(trip.getId(), deleted.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(DailyGoalErrorCode.DAILY_GOAL_ALREADY_DELETED.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/fixture/CreateDailyGoalRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/CreateDailyGoalRequestFixture.java
@@ -1,0 +1,25 @@
+package com.ject.studytrip.trip.fixture;
+
+import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
+import com.ject.studytrip.trip.presentation.dto.request.CreateDailyGoalRequest;
+import java.util.List;
+
+public class CreateDailyGoalRequestFixture {
+
+    private CreatePomodoroRequest pomodoro = new CreatePomodoroRequest(30);
+    private List<Long> missionIds = List.of(1L, 2L);
+
+    public CreateDailyGoalRequestFixture withPomodoro(CreatePomodoroRequest pomodoro) {
+        this.pomodoro = pomodoro;
+        return this;
+    }
+
+    public CreateDailyGoalRequestFixture withMissionIds(List<Long> missionIds) {
+        this.missionIds = missionIds;
+        return this;
+    }
+
+    public CreateDailyGoalRequest build() {
+        return new CreateDailyGoalRequest(pomodoro, missionIds);
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/fixture/DailyGoalFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/DailyGoalFixture.java
@@ -1,0 +1,26 @@
+package com.ject.studytrip.trip.fixture;
+
+import com.ject.studytrip.trip.domain.factory.DailyGoalFactory;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DailyGoalFixture {
+    public static DailyGoal createDailyGoal(Trip trip) {
+        return DailyGoalFactory.create(trip);
+    }
+
+    public static DailyGoal createDailyGoalWithId(Long id, Trip trip) {
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+        ReflectionTestUtils.setField(dailyGoal, "id", id);
+
+        return dailyGoal;
+    }
+
+    public static DailyGoal createDeletedDailyGoal(Trip trip) {
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+        dailyGoal.updateDeletedAt();
+
+        return dailyGoal;
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/fixture/UpdateDailyGoalRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/UpdateDailyGoalRequestFixture.java
@@ -1,0 +1,24 @@
+package com.ject.studytrip.trip.fixture;
+
+import com.ject.studytrip.trip.presentation.dto.request.UpdateDailyGoalRequest;
+import java.util.List;
+
+public class UpdateDailyGoalRequestFixture {
+    private List<Long> deleteDailyMissionIds = null;
+    private List<Long> addMissionIds = null;
+
+    public UpdateDailyGoalRequestFixture withDeleteDailyMissionIds(
+            List<Long> deleteDailyMissionIds) {
+        this.deleteDailyMissionIds = deleteDailyMissionIds;
+        return this;
+    }
+
+    public UpdateDailyGoalRequestFixture withAddMissionIds(List<Long> addMissionIds) {
+        this.addMissionIds = addMissionIds;
+        return this;
+    }
+
+    public UpdateDailyGoalRequest build() {
+        return new UpdateDailyGoalRequest(deleteDailyMissionIds, addMissionIds);
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/helper/DailyGoalTestHelper.java
+++ b/src/test/java/com/ject/studytrip/trip/helper/DailyGoalTestHelper.java
@@ -1,0 +1,26 @@
+package com.ject.studytrip.trip.helper;
+
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
+import com.ject.studytrip.trip.fixture.DailyGoalFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyGoalTestHelper {
+
+    @Autowired private DailyGoalRepository dailyGoalRepository;
+
+    public DailyGoal saveDailyGoal(Trip trip) {
+        DailyGoal dailyGoal = DailyGoalFixture.createDailyGoal(trip);
+        return dailyGoalRepository.save(dailyGoal);
+    }
+
+    public DailyGoal saveDeletedDailyGoal(Trip trip) {
+        DailyGoal dailyGoal = DailyGoalFixture.createDailyGoal(trip);
+        dailyGoal.updateDeletedAt();
+
+        return dailyGoalRepository.save(dailyGoal);
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/DailyGoalControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/DailyGoalControllerIntegrationTest.java
@@ -1,0 +1,1304 @@
+package com.ject.studytrip.trip.presentation.controller;
+
+import static com.ject.studytrip.auth.fixture.TokenFixture.TOKEN_PREFIX;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ject.studytrip.BaseIntegrationTest;
+import com.ject.studytrip.auth.domain.error.AuthErrorCode;
+import com.ject.studytrip.auth.helper.TokenTestHelper;
+import com.ject.studytrip.global.exception.error.CommonErrorCode;
+import com.ject.studytrip.member.domain.model.Member;
+import com.ject.studytrip.member.domain.model.MemberRole;
+import com.ject.studytrip.member.helper.MemberTestHelper;
+import com.ject.studytrip.mission.domain.error.DailyMissionErrorCode;
+import com.ject.studytrip.mission.domain.error.MissionErrorCode;
+import com.ject.studytrip.mission.domain.model.DailyMission;
+import com.ject.studytrip.mission.domain.model.Mission;
+import com.ject.studytrip.mission.helper.DailyMissionTestHelper;
+import com.ject.studytrip.mission.helper.MissionTestHelper;
+import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
+import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
+import com.ject.studytrip.pomodoro.helper.PomodoroTestHelper;
+import com.ject.studytrip.stamp.domain.error.StampErrorCode;
+import com.ject.studytrip.stamp.domain.model.Stamp;
+import com.ject.studytrip.stamp.helper.StampTestHelper;
+import com.ject.studytrip.trip.domain.error.DailyGoalErrorCode;
+import com.ject.studytrip.trip.domain.error.TripErrorCode;
+import com.ject.studytrip.trip.domain.model.DailyGoal;
+import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
+import com.ject.studytrip.trip.fixture.CreateDailyGoalRequestFixture;
+import com.ject.studytrip.trip.fixture.UpdateDailyGoalRequestFixture;
+import com.ject.studytrip.trip.helper.DailyGoalTestHelper;
+import com.ject.studytrip.trip.helper.TripTestHelper;
+import com.ject.studytrip.trip.presentation.dto.request.CreateDailyGoalRequest;
+import com.ject.studytrip.trip.presentation.dto.request.UpdateDailyGoalRequest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("DailyGoalController 통합 테스트")
+public class DailyGoalControllerIntegrationTest extends BaseIntegrationTest {
+    private static final int DEFAULT_ORDER = 1;
+
+    @Autowired private MemberTestHelper memberTestHelper;
+    @Autowired private TripTestHelper tripTestHelper;
+    @Autowired private StampTestHelper stampTestHelper;
+    @Autowired private MissionTestHelper missionTestHelper;
+    @Autowired private DailyGoalTestHelper dailyGoalTestHelper;
+    @Autowired private PomodoroTestHelper pomodoroTestHelper;
+    @Autowired private DailyMissionTestHelper dailyMissionTestHelper;
+    @Autowired private TokenTestHelper tokenTestHelper;
+
+    private Member member;
+    private Trip trip;
+    private Stamp stamp;
+    private Mission firstMission;
+    private Mission secondMission;
+    private DailyGoal dailyGoal;
+    private DailyMission dailyMission;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        member = memberTestHelper.saveMember();
+        trip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+        stamp = stampTestHelper.saveStamp(trip, 1);
+        firstMission = missionTestHelper.saveMission(stamp, DEFAULT_ORDER);
+        secondMission = missionTestHelper.saveMission(stamp, DEFAULT_ORDER + 1);
+        dailyGoal = dailyGoalTestHelper.saveDailyGoal(trip);
+        dailyMission = dailyMissionTestHelper.saveDailyMission(firstMission, dailyGoal);
+        token =
+                tokenTestHelper.createAccessToken(
+                        member.getId().toString(), MemberRole.ROLE_USER.name());
+    }
+
+    @Nested
+    @DisplayName("데일리 목표 생성 API")
+    class CreateDailyGoal {
+        private final CreateDailyGoalRequestFixture fixture = new CreateDailyGoalRequestFixture();
+
+        private ResultActions getResultActions(
+                String token, Object tripId, CreateDailyGoalRequest request) throws Exception {
+            return mockMvc.perform(
+                    post("/api/trips/{tripId}/daily-goals", tripId)
+                            .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)));
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 데일리 목표와 뽀모도로, 데일리 미션을 함께 생성한다")
+        void shouldCreateDailyGoalWithPomodoroAndDailyMissions() throws Exception {
+            // given
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(firstMission.getId(), secondMission.getId()))
+                            .build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.dailyGoalId").isNumber());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 Unauthorized를 반환한다")
+        void shouldReturnUnauthorizedWhenUnauthenticated() throws Exception {
+            // given
+            CreateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions("", trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+            CreateDailyGoalRequest request = fixture.build();
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표를 생성하는데 필요한 필수 요청 값이 누락되거나 유효하지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenInvalidRequiredFields() throws Exception {
+            // given
+            CreateDailyGoalRequest request =
+                    fixture.withPomodoro(null).withMissionIds(List.of()).build();
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+            CreateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행의 소유자가 아닐 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+            CreateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+            CreateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, deleted.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 미션 ID 목록으로 해당 미션을 조회하고, 하나라도 일치하지 않는 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenAnyMissionIdDoesNotExist() throws Exception {
+            // given
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(firstMission.getId(), 1000L)).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(MissionErrorCode.MISSION_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("코스형 여행에서 현재 진행중인 스탬프(완료되지 않은 가장 첫번째 스탬프)가 없을 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenNotFoundWhenNoIncompleteStampExists() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            stampTestHelper.saveCompletedStamp(newTrip, 1);
+            CreateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(StampErrorCode.STAMP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("조회된 미션들의 스탬프 정보를 확인해 요청한 여행에 속하지 않으면 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenMissionsStampsDoesNotBelongToTrip() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            stampTestHelper.saveStamp(newTrip, 1);
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(firstMission.getId())).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, newTrip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("조회된 미션들 중 삭제된 미션이 존재하면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenMissionIsDeleted() throws Exception {
+            // given
+            Mission deleted = missionTestHelper.saveDeletedMission(stamp, DEFAULT_ORDER);
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(deleted.getId())).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("조회된 미션들 중 완료된 미션이 존재하면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenMissionIsAlreadyCompleted() throws Exception {
+            // given
+            Mission completed = missionTestHelper.saveCompletedMission(stamp, DEFAULT_ORDER);
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(completed.getId())).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_ALREADY_COMPLETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("코스형 여행에서 조회된 미션들이 현재 진행중인 스탬프에 속하지 않은 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenMissionNotBelongToCurrentStamp() throws Exception {
+            // given
+            Stamp newStamp = stampTestHelper.saveStamp(trip, 2);
+            Mission newMission = missionTestHelper.saveMission(newStamp, DEFAULT_ORDER);
+            CreateDailyGoalRequest request =
+                    fixture.withMissionIds(List.of(newMission.getId())).build();
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_NOT_BELONGS_TO_STAMP
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 목표 수정 API")
+    class UpdateDailyGoal {
+        private final UpdateDailyGoalRequestFixture fixture = new UpdateDailyGoalRequestFixture();
+
+        private ResultActions getResultActions(
+                String token, Object tripId, Object dailyGoalId, UpdateDailyGoalRequest request)
+                throws Exception {
+            return mockMvc.perform(
+                    patch("/api/trips/{tripId}/daily-goals/{dailyGoalId}", tripId, dailyGoalId)
+                            .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)));
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 특정 데일리 목표에 속한 데일리 미션을 수정한다")
+        void shouldUpdateDailyGoal() throws Exception {
+            // given
+            Mission addMission = missionTestHelper.saveMission(stamp, DEFAULT_ORDER);
+            UpdateDailyGoalRequest request =
+                    fixture.withDeleteDailyMissionIds(List.of(dailyMission.getId()))
+                            .withAddMissionIds(List.of(addMission.getId()))
+                            .build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 Unauthorized를 반환한다")
+        void shouldReturnUnauthorizedWhenUnauthenticated() throws Exception {
+            // given
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions("", trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, tripId, dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 데일리 목표 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDailyGoalIdTypeMismatch() throws Exception {
+            // given
+            String dailyGoalId = "abc";
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoalId, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, tripId, dailyGoal.getId(), request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행의 소유자가 아닐 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, deleted.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 데일리 목표 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidDailyGoalId() throws Exception {
+            // given
+            Long dailyGoalId = 10000L;
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoalId, request);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("조회된 데일리 목표가 요청한 여행에 속하지 않을 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenDailyGoalNotBelongToTrip() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            DailyGoal newDailyGoal = dailyGoalTestHelper.saveDailyGoal(newTrip);
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), newDailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 데일리 목표일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyDailyGoal() throws Exception {
+            // given
+            DailyGoal deleted = dailyGoalTestHelper.saveDeletedDailyGoal(trip);
+            UpdateDailyGoalRequest request = fixture.build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), deleted.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제를 요청한 데일리 미션 ID 개수와 조회된 데일리 미션 개수가 다르면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenAnyDeleteTargetDailyMissionDoesNotExist() throws Exception {
+            // given
+            List<Long> ids = List.of(dailyMission.getId(), 1000L);
+            UpdateDailyGoalRequest request = fixture.withDeleteDailyMissionIds(ids).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyMissionErrorCode.DAILY_MISSION_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제를 요청한 데일리 미션이 요청한 데일리 목표에 속하지 않으면 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenDeleteTargetDailyMissionDoesNotBelongToDailyGoal()
+                throws Exception {
+            // given
+            DailyGoal newDailyGoal = dailyGoalTestHelper.saveDailyGoal(trip);
+            DailyMission newDailyMission =
+                    dailyMissionTestHelper.saveDailyMission(firstMission, newDailyGoal);
+            UpdateDailyGoalRequest request =
+                    fixture.withDeleteDailyMissionIds(List.of(newDailyMission.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyMissionErrorCode
+                                                    .DAILY_MISSION_NOT_BELONG_TO_DAILY_GOAL
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 미션이 이미 삭제된 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDeleteTargetDailyMissionIsAlreadyDeleted() throws Exception {
+            // given
+            dailyMission.updateDeletedAt();
+            UpdateDailyGoalRequest request =
+                    fixture.withDeleteDailyMissionIds(List.of(dailyMission.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyMissionErrorCode.DAILY_MISSION_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("추가할 미션 ID 목록으로 해당 미션을 조회하고, 하나라도 일치하지 않는 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenAnyAddMissionIdDoesNotExist() throws Exception {
+            // given
+            UpdateDailyGoalRequest request =
+                    fixture.withAddMissionIds(List.of(100L, 200L, 300L)).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(MissionErrorCode.MISSION_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("코스형 여행에서 현재 진행중인 스탬프(완료되지 않은 가장 첫번째 스탬프)가 없을 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenNoIncompleteStampExists() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            stampTestHelper.saveCompletedStamp(newTrip, 1);
+            DailyGoal newDailyGoal = dailyGoalTestHelper.saveDailyGoal(newTrip);
+            UpdateDailyGoalRequest request = fixture.withAddMissionIds(List.of(1L)).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), newDailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(StampErrorCode.STAMP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("새로 추가할 미션들의 스탬프 정보를 확인해 요청한 여행에 속하지 않으면 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenAddMissionsStampsDoesNotBelongToTrip() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            Stamp newStamp = stampTestHelper.saveStamp(newTrip, 1);
+            Mission newMission = missionTestHelper.saveMission(newStamp, DEFAULT_ORDER);
+            UpdateDailyGoalRequest request =
+                    fixture.withAddMissionIds(List.of(newMission.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            StampErrorCode.STAMP_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("새로 추가할 미션들 중 삭제된 미션이 존재하면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAnyAddMissionIsDeleted() throws Exception {
+            // given
+            Mission deleted = missionTestHelper.saveDeletedMission(stamp, DEFAULT_ORDER);
+            UpdateDailyGoalRequest request =
+                    fixture.withAddMissionIds(List.of(deleted.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("새로 추가할 미션들 중 완료된 미션이 존재하면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAnyAddMissionIsAlreadyCompleted() throws Exception {
+            // given
+            Mission completed = missionTestHelper.saveCompletedMission(stamp, DEFAULT_ORDER);
+            UpdateDailyGoalRequest request =
+                    fixture.withAddMissionIds(List.of(completed.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_ALREADY_COMPLETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("코스형 여행에서 새로 추가한 미션들이 현재 진행중인 스탬프에 속하지 않은 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAddMissionsDoNotBelongToCurrentStamp() throws Exception {
+            // given
+            Stamp newStamp = stampTestHelper.saveStamp(trip, 2);
+            Mission newMission = missionTestHelper.saveMission(newStamp, DEFAULT_ORDER);
+            UpdateDailyGoalRequest request =
+                    fixture.withAddMissionIds(List.of(newMission.getId())).build();
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MissionErrorCode.MISSION_NOT_BELONGS_TO_STAMP
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 목표 삭제 API")
+    class DeleteDailyGoal {
+
+        private ResultActions getResultActions(String token, Object tripId, Object dailyGoalId)
+                throws Exception {
+            return mockMvc.perform(
+                    delete("/api/trips/{tripId}/daily-goals/{dailyGoalId}", tripId, dailyGoalId)
+                            .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + token));
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 데일리 목표와 뽀모도로, 데일리 미션을 삭제한다")
+        void shouldDeleteDailyGoalAndPomodoroAndDailyMissions() throws Exception {
+            // given
+            pomodoroTestHelper.savePomodoro(dailyGoal);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 Unauthorized를 반환한다")
+        void shouldReturnUnauthorizedWhenUnauthenticated() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions("", trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 데일리 목표 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDailyGoalIdTypeMismatch() throws Exception {
+            // given
+            String dailyGoalId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoalId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, dailyGoal.getId());
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행의 소유자가 아닐 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, deleted.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 데일리 목표 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidDailyGoalId() throws Exception {
+            // given
+            Long dailyGoalId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoalId);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("조회된 데일리 목표가 요청한 여행에 속하지 않을 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenDailyGoalNotBelongToTrip() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            DailyGoal newDailyGoal = dailyGoalTestHelper.saveDailyGoal(newTrip);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), newDailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 데일리 목표일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyDailyGoal() throws Exception {
+            // given
+            DailyGoal deleted = dailyGoalTestHelper.saveDeletedDailyGoal(trip);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), deleted.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표 ID로 뽀모도로를 조회하고 존재하지 않을 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenPomodoroDoesNotExist() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            PomodoroErrorCode.POMODORO_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표 ID로 뽀모도로를 조회하고 이미 삭제된 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenPomodoroIsAlreadyDeleted() throws Exception {
+            // given
+            pomodoroTestHelper.saveDeletedPomodoro(dailyGoal);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            PomodoroErrorCode.POMODORO_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+
+    @Nested
+    @DisplayName("데일리 목표 조회 API")
+    class GetDailyGoal {
+
+        private ResultActions getResultActions(String token, Object tripId, Object dailyGoalId)
+                throws Exception {
+            return mockMvc.perform(
+                    get("/api/trips/{tripId}/daily-goals/{dailyGoalId}", tripId, dailyGoalId)
+                            .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + token));
+        }
+
+        @Test
+        @DisplayName("유효한 정보로 특정 데일리 목표를 조회하고 해당 뽀모도로와 데일리 미션을 함께 반환한다")
+        void shouldReturnDailyGoal() throws Exception {
+            // given
+            Pomodoro pomodoro = pomodoroTestHelper.savePomodoro(dailyGoal);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.dailyGoalId").value(dailyGoal.getId()))
+                    .andExpect(jsonPath("$.data.pomodoro.pomodoroId").value(pomodoro.getId()))
+                    .andExpect(jsonPath("$.data.dailyMissions").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자일 경우 401 Unauthorized를 반환한다")
+        void shouldReturnUnauthorizedWhenUnauthenticated() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions("", trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 여행 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenTripIdTypeMismatch() throws Exception {
+            // given
+            String tripId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("PathVariable 데일리 목표 ID 타입이 올바르지 않으면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDailyGoalIdTypeMismatch() throws Exception {
+            // given
+            String dailyGoalId = "abc";
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoalId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 여행 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidTripId() throws Exception {
+            // given
+            Long tripId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, tripId, dailyGoal.getId());
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_NOT_FOUND.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("요청한 여행의 소유자가 아닐 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenNotTripOwner() throws Exception {
+            // given
+            Member newMember = memberTestHelper.saveMember("test@gmail.com", "TEST");
+            Trip newTrip = tripTestHelper.saveTrip(newMember, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, newTrip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.NOT_TRIP_OWNER.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 여행일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyTrip() throws Exception {
+            // given
+            Trip deleted = tripTestHelper.saveDeletedTrip(member, TripCategory.COURSE);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, deleted.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 데일리 목표 ID 라면 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenInvalidDailyGoalId() throws Exception {
+            // given
+            Long dailyGoalId = 10000L;
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoalId);
+
+            // when & then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("조회된 데일리 목표가 요청한 여행에 속하지 않을 경우 403 Forbidden을 반환한다")
+        void shouldReturnForbiddenWhenDailyGoalNotBelongToTrip() throws Exception {
+            // given
+            Trip newTrip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
+            DailyGoal newDailyGoal = dailyGoalTestHelper.saveDailyGoal(newTrip);
+
+            // when
+            ResultActions resultActions =
+                    getResultActions(token, trip.getId(), newDailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_NOT_BELONG_TO_TRIP
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("삭제된 데일리 목표일 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenAlreadyDailyGoal() throws Exception {
+            // given
+            DailyGoal deleted = dailyGoalTestHelper.saveDeletedDailyGoal(trip);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), deleted.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            DailyGoalErrorCode.DAILY_GOAL_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표 ID로 뽀모도로를 조회하고 존재하지 않을 경우 404 NotFound를 반환한다")
+        void shouldReturnNotFoundWhenPomodoroDoesNotExist() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            PomodoroErrorCode.POMODORO_NOT_FOUND
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표 ID로 뽀모도로를 조회하고 이미 삭제된 경우 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenPomodoroIsAlreadyDeleted() throws Exception {
+            // given
+            pomodoroTestHelper.saveDeletedPomodoro(dailyGoal);
+
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), dailyGoal.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            PomodoroErrorCode.POMODORO_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 데일리 목표 생성 API
- 여행에서 여러 미션을 조합해 학습할 수 있는 데일리 목표를 생성하는 기능 구현
- 생성 요청 시, `뽀모도로(Pomodoro)`와 `미션(Mission)`정보를 같이 전달하고 `뽀모도로(Pomodoro)`, `데일리 미션(DailyMission)`을 함께 생성
-> 현재는 뽀모도로 생성 요청 시` focusDurationInMinute(집중 시간)`만 입력받지만, 추후 고도화에 따라 필드 확장을 고려
- 코스형 여행의 경우 현재 진행중인 스탬프를 조회(전체 스탬프 중 `completed` 필드가 `false`인 가장 첫번째 스탬프)하고 해당 스탬프에 속한 미션들인지 검증

### ✅ 데일리 목표 수정 API
- 기존 데일리 목표에 포함된 데일리 미션을 수정할 수 있는 기능 구현
- 클라이언트로부터 삭제할 데일리 미션 ID 목록과 새로 추가할 미션 ID 목록을 전달받아 처리하도록 구현
- `PATCH` 요청으로 원하는 필드만 요청

### ✅ 데일리 목표 삭제 API
- 데일리 목표의 `deletedAt` 필드를 요청한 시간으로 수정해 `Soft Delete` 수행 
- 해당 데일리 목표에 포함된 `뽀모도로(Pomodoro)`, `데일리 미션(DailyMission)`도 함께 논리 삭제되도록 구성

### ✅ 특정 데일리 목표 조회 API
- 데일리 목표 ID로 특정 `DailyGoal` 정보를 조회하는 기능 구현
- 해당 데일리 목표에 포함된 `뽀모도로(Pomodoro)`, `데일리 미션(DailyMission)` 정보들도 함께 반환하도록 구성

### ✅ Mission, Stamp 서비스 로직 추가
- 미션 ID 목록을 기반으로 미션들을 조회할 때, 각 미션과 연관된 `Stamp`를 `fetch join`해 조회하고, 검증 후 유효한 미션 목록을 반환하는 로직 추가
- 코스형 여행의 경우, 현재 진행중인 `Stamp`(아직 완료되지 않은 가장 첫 번째 `Stamp`)를 조회하는 로직 추가
: `completed` 필드가 `false`인 가장 첫번째 `Stamp`를 조회하도록 구성

### ✅ fetch join 쿼리 구성
- 데일리 목표를 생성하거나 수정하는 과정에서 요청한 미션들이 유효한지 검증하기 위해 각 미션과 연관된 스탬프 정보가 필요합니다. 미션이 여러 개이고 `Lazy loading`인 상황에서 `mission.getStamp()`를 매번 하게되면 호출할 때마다 불필요한 쿼리가 발생하는 `N+1` 문제가 발생하고 이를 방지하고자 `fetch join`를 사용했습니다.
- 또한, 특정 데일리 목표를 조회할 때 해당 목표에 포함된 데일리 미션 목록과 그에 연결된 `Mission` 정보를 함께 가공하는데 이 경우에도 `DailyMission -> Mission` 관계에서 `fetch join`을 적용해 불필요한 쿼리 발생을 방지했습니다.

### ✅ 테스트
- `DailyGoal`, `Pomodoro`, `DailyMission` `Fixture` 및 `Helper` 클래스 작성
- `DailyGoalController` 통합 테스트 작성
- 각 서비스 단위 테스트 작성
: `DailyGoal` 서비스 단위 테스트 작성
: `Pomodoro` 서비스 단위 테스트 작성
: `DailyMission` 서비스 단위 테스트 작성
: `Mission` 서비스 단위 테스트에 미션과 스탬프를 `fetch join` 하고 검증된 미션 목록을 조회하는 테스트 작성
: `Stamp` 서비스 단위 테스트에 코스형 여행일 경우 현재 진행중인 스탬프를 조회하는 테스트 작성

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #38 

<br/>

## 🔍 참고사항(선택)

- 현재 피그마에는 데일리 목표 수정 화면이 없어, 임의로 UI 흐름을 구성한 상태입니다. 추후 변경사항이 생기면 즉시 반영하겠습니다.

- 데일리 목표 수정 API에서는 `Pomodoro` 정보는 수정하지 않도록 구성했습니다.
피그마 상에서는 `Pomodoro` 시간을 탭하면 모달을 통해 수정하는 방식으로 되어 있어, `Pomodoro` 수정은 별도의 API로 분리해도 될 것 같다고 생각했습니다. 이 부분도 추후 변경사항이 생기면 즉시 반영하겠습니다.

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-