### PR TITLE
fix: 로컬 클라이언트 도메인 포트 5173으로 변경(#41)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
@@ -10,8 +10,8 @@ public enum UrlConstants {
     LOCAL_API_SERVER_URL("http://localhost:8080"),
 
     // TODO: 개발, 운영 도메인 URL 추가 작업
-    LOCAL_DOMAIN_URL("http://localhost:3000"),
-    LOCAL_SECURE_DOMAIN_URL("https://localhost:3000"),
+    LOCAL_DOMAIN_URL("http://localhost:5173"),
+    LOCAL_SECURE_DOMAIN_URL("https://localhost:5173"),
     ;
 
     private final String value;


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 로컬 클라이언트 도메인 URL 변경
- `Spring Security`의 CORS 설정에서 허용된 Origin 중 클라이언트 도메인 포트가 잘못되어 CORS 에러 발생
- `UrlConstants` 클래스에서 잘못된 포트(3000번)를 올바른 포트(5173번)로 수정하여 에러 해결

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #41 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-