### PR TITLE
chore: 배포된 클라이언트 URL 등록(#45)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/ject/studytrip/global/common/constants/UrlConstants.java
@@ -9,9 +9,9 @@ public enum UrlConstants {
     DEV_API_SERVER_URL("https://dev-api-studytrip.duckdns.org"),
     LOCAL_API_SERVER_URL("http://localhost:8080"),
 
-    // TODO: 개발, 운영 도메인 URL 추가 작업
-    LOCAL_DOMAIN_URL("http://localhost:5173"),
-    LOCAL_SECURE_DOMAIN_URL("https://localhost:5173"),
+    PRODUCTION_CLIENT_URL("https://ject-4-client.vercel.app"),
+    LOCAL_CLIENT_URL("http://localhost:5173"),
+    LOCAL_SECURE_CLIENT_URL("https://localhost:5173"),
     ;
 
     private final String value;


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 배포된 클라이언트 URL 등록
- `UrlConstants` enum 클래스에 배포된 클라이언트 URL 추가
- `WebSecurityConfig` CORS 설정에서 `UrlConstants` enum 클래스의 모든 URL을 허용하도록 설정해, 자동으로 배포된 클라이언트 URL CORS 허용

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #45 

<br/>

## 🔍 참고사항(선택)

- 카카오 앱 `Redirect URI` 에도 배포된 클라이언트 URL을 등록시켜주어야 합니다.

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-