### PR TITLE
refactor: 카카오 로그인 멤버 조회 로직 개선(#54)

### DIFF
--- a/src/main/java/com/ject/studytrip/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/ject/studytrip/auth/presentation/controller/AuthController.java
@@ -30,6 +30,7 @@ public class AuthController {
     public ResponseEntity<StandardResponse> kakaoLogin(
             @Valid @RequestBody KakaoLoginRequest request) {
         TokenResponse response = authFacade.kakaoLogin(request);
+
         return ResponseEntity.ok(StandardResponse.success(HttpStatus.OK.value(), response));
     }
 
@@ -40,6 +41,7 @@ public class AuthController {
     public ResponseEntity<StandardResponse> kakaoSignup(
             @Valid @RequestBody KakaoSignupRequest request) {
         TokenResponse response = authFacade.kakaoSignup(request);
+
         return ResponseEntity.ok(StandardResponse.success(HttpStatus.OK.value(), response));
     }
 
@@ -48,6 +50,7 @@ public class AuthController {
     public ResponseEntity<StandardResponse> reissueToken(
             @Valid @RequestBody TokenReissueRequest request) {
         TokenResponse response = authFacade.reissueToken(request);
+
         return ResponseEntity.ok(StandardResponse.success(HttpStatus.OK.value(), response));
     }
 
@@ -57,6 +60,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<StandardResponse> logout(@Valid @RequestBody LogoutRequest request) {
         authFacade.logout(request);
+
         return ResponseEntity.ok(StandardResponse.success(HttpStatus.OK.value(), null));
     }
 }

--- a/src/main/java/com/ject/studytrip/member/application/service/MemberService.java
+++ b/src/main/java/com/ject/studytrip/member/application/service/MemberService.java
@@ -62,9 +62,14 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member getMemberBySocialProviderAndSocialId(
             SocialProvider socialProvider, String socialId) {
-        return memberRepository
-                .findBySocialProviderAndSocialId(socialProvider, socialId)
-                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NEED_SIGNUP));
+        Member member =
+                memberRepository
+                        .findBySocialProviderAndSocialId(socialProvider, socialId)
+                        .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NEED_SIGNUP));
+
+        MemberPolicy.validateNotDeleted(member);
+
+        return member;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/ject/studytrip/auth/helper/KakaoOauthTestHelper.java
+++ b/src/test/java/com/ject/studytrip/auth/helper/KakaoOauthTestHelper.java
@@ -1,0 +1,35 @@
+package com.ject.studytrip.auth.helper;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.ject.studytrip.auth.infra.dto.KakaoTokenResponse;
+import com.ject.studytrip.auth.infra.dto.KakaoUserInfoResponse;
+import com.ject.studytrip.auth.infra.provider.KakaoOauthProvider;
+import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.member.domain.error.MemberErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoOauthTestHelper {
+    private final KakaoOauthProvider kakaoOauthProvider;
+
+    @Autowired
+    public KakaoOauthTestHelper(KakaoOauthProvider kakaoOauthProvider) {
+        this.kakaoOauthProvider = kakaoOauthProvider;
+    }
+
+    public void mockSuccess(
+            KakaoTokenResponse kakaoTokenResponse, KakaoUserInfoResponse kakaoUserInfoResponse) {
+        given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
+        given(kakaoOauthProvider.getKakaoUserInfo(anyString())).willReturn(kakaoUserInfoResponse);
+    }
+
+    public void mockThrowException(
+            KakaoTokenResponse kakaoTokenResponse, MemberErrorCode memberErrorCode) {
+        given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
+        given(kakaoOauthProvider.getKakaoUserInfo(anyString()))
+                .willThrow(new CustomException(memberErrorCode));
+    }
+}

--- a/src/test/java/com/ject/studytrip/auth/helper/TokenTestHelper.java
+++ b/src/test/java/com/ject/studytrip/auth/helper/TokenTestHelper.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TokenTestHelper {
-
     private final TokenProvider tokenProvider;
 
     @Autowired

--- a/src/test/java/com/ject/studytrip/auth/presentation/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/auth/presentation/controller/AuthControllerIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.ject.studytrip.auth.presentation.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -10,6 +8,7 @@ import com.ject.studytrip.auth.domain.error.AuthErrorCode;
 import com.ject.studytrip.auth.domain.repository.RefreshTokenRedisRepository;
 import com.ject.studytrip.auth.fixture.*;
 import com.ject.studytrip.auth.fixture.TokenReissueRequestFixture;
+import com.ject.studytrip.auth.helper.KakaoOauthTestHelper;
 import com.ject.studytrip.auth.helper.TokenTestHelper;
 import com.ject.studytrip.auth.infra.dto.KakaoTokenResponse;
 import com.ject.studytrip.auth.infra.dto.KakaoUserInfoResponse;
@@ -18,7 +17,6 @@ import com.ject.studytrip.auth.presentation.dto.request.KakaoLoginRequest;
 import com.ject.studytrip.auth.presentation.dto.request.KakaoSignupRequest;
 import com.ject.studytrip.auth.presentation.dto.request.LogoutRequest;
 import com.ject.studytrip.auth.presentation.dto.request.TokenReissueRequest;
-import com.ject.studytrip.global.exception.CustomException;
 import com.ject.studytrip.global.exception.error.CommonErrorCode;
 import com.ject.studytrip.member.domain.error.MemberErrorCode;
 import com.ject.studytrip.member.domain.model.Member;
@@ -40,6 +38,7 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private MemberTestHelper memberTestHelper;
     @Autowired private TokenTestHelper tokenTestHelper;
+    @Autowired private KakaoOauthTestHelper kakaoOauthTestHelper;
     @Autowired private RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @MockitoBean KakaoOauthProvider kakaoOauthProvider;
@@ -55,6 +54,7 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 tokenTestHelper.createAccessToken(
                         member.getId().toString(), member.getRole().name());
         refreshToken = tokenTestHelper.createRefreshToken();
+
         long refreshTokenExpirationTime = Duration.ofSeconds(30).getSeconds();
         refreshTokenRedisRepository.saveRefreshToken(
                 member.getId().toString(), refreshToken, refreshTokenExpirationTime);
@@ -84,10 +84,8 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
             member.updateDeletedAt();
             KakaoLoginRequest request = kakaoLoginRequestFixture.build();
             KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseFixture.build();
-
-            given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
-            given(kakaoOauthProvider.getKakaoUserInfo(anyString()))
-                    .willThrow(new CustomException(MemberErrorCode.MEMBER_NEED_SIGNUP));
+            kakaoOauthTestHelper.mockThrowException(
+                    kakaoTokenResponse, MemberErrorCode.MEMBER_NEED_SIGNUP);
 
             // when
             ResultActions resultActions = getResultActions(request);
@@ -108,16 +106,41 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
+        @DisplayName("탈퇴한 사용자가 인가 코드로 로그인 시 400 Bad Request를 반환한다.")
+        void shouldReturnBadRequestWhenMemberAlreadyDeleted() throws Exception {
+            // given
+            member.updateDeletedAt();
+            KakaoLoginRequest request = kakaoLoginRequestFixture.build();
+            KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseFixture.build();
+            kakaoOauthTestHelper.mockThrowException(
+                    kakaoTokenResponse, MemberErrorCode.MEMBER_ALREADY_DELETED);
+
+            // when
+            ResultActions resultActions = getResultActions(request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            MemberErrorCode.MEMBER_ALREADY_DELETED
+                                                    .getStatus()
+                                                    .value()))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(MemberErrorCode.MEMBER_ALREADY_DELETED.getMessage()));
+        }
+
+        @Test
         @DisplayName("가입된 사용자의 인가 코드로 로그인하면 토큰이 발급된다.")
         void shouldReturnTokenResponseWhenLoginIsSuccessful() throws Exception {
             // given
             KakaoLoginRequest request = kakaoLoginRequestFixture.build();
             KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseFixture.build();
             KakaoUserInfoResponse kakaoUserInfoResponse = kakaoUserInfoResponseFixture.build();
-
-            given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
-            given(kakaoOauthProvider.getKakaoUserInfo(anyString()))
-                    .willReturn(kakaoUserInfoResponse);
+            kakaoOauthTestHelper.mockSuccess(kakaoTokenResponse, kakaoUserInfoResponse);
 
             // when
             ResultActions resultActions = getResultActions(request);
@@ -156,10 +179,7 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
             KakaoSignupRequest request = kakaoSignupRequestFixture.build();
             KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseFixture.build();
             KakaoUserInfoResponse kakaoUserInfoResponse = kakaoUserInfoResponseFixture.build();
-
-            given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
-            given(kakaoOauthProvider.getKakaoUserInfo(anyString()))
-                    .willReturn(kakaoUserInfoResponse);
+            kakaoOauthTestHelper.mockSuccess(kakaoTokenResponse, kakaoUserInfoResponse);
 
             // when
             ResultActions resultActions = getResultActions(request);
@@ -187,10 +207,7 @@ class AuthControllerIntegrationTest extends BaseIntegrationTest {
             KakaoSignupRequest request = kakaoSignupRequestFixture.build();
             KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseFixture.build();
             KakaoUserInfoResponse kakaoUserInfoResponse = kakaoUserInfoResponseFixture.build();
-
-            given(kakaoOauthProvider.getKakaoTokens(anyString())).willReturn(kakaoTokenResponse);
-            given(kakaoOauthProvider.getKakaoUserInfo(anyString()))
-                    .willReturn(kakaoUserInfoResponse);
+            kakaoOauthTestHelper.mockSuccess(kakaoTokenResponse, kakaoUserInfoResponse);
 
             // when
             ResultActions resultActions = getResultActions(request);

--- a/src/test/java/com/ject/studytrip/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/ject/studytrip/member/application/service/MemberServiceTest.java
@@ -266,6 +266,23 @@ class MemberServiceTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("탈퇴한 Member라면 예외가 발생한다.")
+        void shouldThrowExceptionWhenMemberAlreadyDeleted() {
+            // given
+            member.updateDeletedAt();
+            given(memberRepository.findBySocialProviderAndSocialId(SocialProvider.KAKAO, socialId))
+                    .willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    memberService.getMemberBySocialProviderAndSocialId(
+                                            SocialProvider.KAKAO, socialId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
         @DisplayName("소셜 ID로 조회 시 존재하면 Member를 반환한다.")
         void shouldReturnMemberWhenSocialIdExists() {
             // given


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 카카오 로그인 멤버 조회 메서드에 삭제 검증 로직 추가
- `MemberService.getMemberBySocialProviderAndSocialId()`에 `MemberPolicy.validateNotDeleted()` 추가

### ✅ 테스트
- `MemberServiceTest`: `GetMemberBySocialProviderAndSocialId`에 **탈퇴 회원 예외 발생** 테스트 추가
- `AuthControllerIntegrationTest`: `KakaoLogin`에  **탈퇴 회원 예외 발생** 테스트 추가
- `KakaoOauthTestHelper` 추가
<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #54 

<br/>

## 🔍 참고사항(선택)
- `KakaoOauthTestHelper`를 통해 카카오 토큰 발급 및 사용자 정보 조회 **Mocking**을 간결하게 구성했습니다.

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-