### PR TITLE
refactor: 뽀모도로 집중 세션 개수를 요청받도록 리팩토링(#57)

### DIFF
--- a/src/main/java/com/ject/studytrip/pomodoro/application/dto/PomodoroInfo.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/dto/PomodoroInfo.java
@@ -2,8 +2,11 @@ package com.ject.studytrip.pomodoro.application.dto;
 
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 
-public record PomodoroInfo(Long pomodoroId, int focusDurationInMinute) {
+public record PomodoroInfo(Long pomodoroId, int focusDurationInMinute, int focusSessionCount) {
     public static PomodoroInfo from(Pomodoro pomodoro) {
-        return new PomodoroInfo(pomodoro.getId(), pomodoro.getFocusDurationInSeconds() / 60);
+        return new PomodoroInfo(
+                pomodoro.getId(),
+                pomodoro.getFocusDurationInSeconds() / 60,
+                pomodoro.getFocusSessionCount());
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
@@ -18,7 +18,9 @@ public class PomodoroService {
 
     public Pomodoro createPomodoro(DailyGoal dailyGoal, CreatePomodoroRequest request) {
         int focusDurationInSeconds = request.focusDurationInMinute() * 60;
-        Pomodoro pomodoro = PomodoroFactory.create(dailyGoal, focusDurationInSeconds, 1, 0);
+        Pomodoro pomodoro =
+                PomodoroFactory.create(
+                        dailyGoal, focusDurationInSeconds, request.focusSessionCount(), 0);
         return pomodoroRepository.save(pomodoro);
     }
 

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/factory/PomodoroFactory.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/factory/PomodoroFactory.java
@@ -10,8 +10,9 @@ public class PomodoroFactory {
     public static Pomodoro create(
             DailyGoal dailyGoal,
             int focusDurationInSeconds,
-            int focusCount,
+            int focusSessionCount,
             int breakDurationInSeconds) {
-        return Pomodoro.of(dailyGoal, focusDurationInSeconds, focusCount, breakDurationInSeconds);
+        return Pomodoro.of(
+                dailyGoal, focusDurationInSeconds, focusSessionCount, breakDurationInSeconds);
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/model/Pomodoro.java
@@ -22,7 +22,7 @@ public class Pomodoro extends BaseTimeEntity {
     private DailyGoal dailyGoal;
 
     private int focusDurationInSeconds; // 집중 시간(초)
-    private int focusCount; // 집중 세션 횟수
+    private int focusSessionCount; // 집중 세션 횟수
     private int breakDurationInSeconds; // 휴식 시간(초)
     private int totalFocusTimeInSeconds; // 총 집중 시간(초)
 
@@ -31,12 +31,12 @@ public class Pomodoro extends BaseTimeEntity {
     public static Pomodoro of(
             DailyGoal dailyGoal,
             int focusDurationInSeconds,
-            int focusCount,
+            int focusSessionCount,
             int breakDurationInSeconds) {
         return Pomodoro.builder()
                 .dailyGoal(dailyGoal)
                 .focusDurationInSeconds(focusDurationInSeconds)
-                .focusCount(1)
+                .focusSessionCount(focusSessionCount)
                 .breakDurationInSeconds(0)
                 .totalFocusTimeInSeconds(0)
                 .build();

--- a/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
@@ -3,4 +3,5 @@ package com.ject.studytrip.pomodoro.presentation.dto.request;
 import jakarta.validation.constraints.Min;
 
 public record CreatePomodoroRequest(
-        @Min(value = 1, message = "뽀모도로 최소 집중 시간은 1분입니다.") int focusDurationInMinute) {}
+        @Min(value = 1, message = "뽀모도로 최소 집중 시간은 1분입니다.") int focusDurationInMinute,
+        @Min(value = 1, message = "뽀모도로 최소 집중 세션 개수는 1개입니다.") int focusSessionCount) {}

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
@@ -25,9 +25,11 @@ public record LoadDailyGoalDetailResponse(
 
     public record DailyGoalPomodoroResponse(
             @Schema(name = "뽀모도로 ID") Long pomodoroId,
-            @Schema(name = "뽀모도로 집중 시간(분)") int focusDurationInMinute) {
+            @Schema(name = "뽀모도로 집중 시간(분)") int focusDurationInMinute,
+            @Schema(name = "뽀모도로 집중 세션 개수") int focusSessionCount) {
         public static DailyGoalPomodoroResponse of(PomodoroInfo info) {
-            return new DailyGoalPomodoroResponse(info.pomodoroId(), info.focusDurationInMinute());
+            return new DailyGoalPomodoroResponse(
+                    info.pomodoroId(), info.focusDurationInMinute(), info.focusSessionCount());
         }
     }
 

--- a/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
@@ -52,7 +52,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
         @DisplayName("뽀모도로를 생성해 저장하고 반환한다")
         void shouldCreateAndReturnPomodoro() {
             // given
-            CreatePomodoroRequest request = new CreatePomodoroRequest(30);
+            CreatePomodoroRequest request = new CreatePomodoroRequest(30, 1);
             given(pomodoroRepository.save(any())).willReturn(pomodoro);
 
             // when
@@ -61,6 +61,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
             // then
             assertThat(result).isNotNull();
             assertThat(result.getFocusDurationInSeconds()).isEqualTo(30 * 60);
+            assertThat(result.getFocusSessionCount()).isEqualTo(1);
         }
     }
 

--- a/src/test/java/com/ject/studytrip/trip/fixture/CreateDailyGoalRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/CreateDailyGoalRequestFixture.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class CreateDailyGoalRequestFixture {
 
-    private CreatePomodoroRequest pomodoro = new CreatePomodoroRequest(30);
+    private CreatePomodoroRequest pomodoro = new CreatePomodoroRequest(30, 1);
     private List<Long> missionIds = List.of(1L, 2L);
 
     public CreateDailyGoalRequestFixture withPomodoro(CreatePomodoroRequest pomodoro) {

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/DailyGoalControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/DailyGoalControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import com.ject.studytrip.mission.helper.MissionTestHelper;
 import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 import com.ject.studytrip.pomodoro.helper.PomodoroTestHelper;
+import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.helper.StampTestHelper;
@@ -158,6 +159,50 @@ public class DailyGoalControllerIntegrationTest extends BaseIntegrationTest {
             // given
             CreateDailyGoalRequest request =
                     fixture.withPomodoro(null).withMissionIds(List.of()).build();
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표의 뽀모도로 정보 중 집중 시간이 1분 미만이면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDailyGoalPomodoroFocusTimeInMinuteIsLessThanOneMinute()
+                throws Exception {
+            // given
+            CreateDailyGoalRequest request =
+                    fixture.withPomodoro(new CreatePomodoroRequest(0, 1)).build();
+            // when
+            ResultActions resultActions = getResultActions(token, trip.getId(), request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(
+                                            CommonErrorCode.METHOD_ARGUMENT_NOT_VALID
+                                                    .getStatus()
+                                                    .value()));
+        }
+
+        @Test
+        @DisplayName("데일리 목표의 뽀모도로 정보 중 집중 세션이 1개 미만이면 400 Bad Request를 반환한다")
+        void shouldReturnBadRequestWhenDailyGoalPomodoroFocusSessionCountIsLessThanOne()
+                throws Exception {
+            // given
+            CreateDailyGoalRequest request =
+                    fixture.withPomodoro(new CreatePomodoroRequest(30, 0)).build();
             // when
             ResultActions resultActions = getResultActions(token, trip.getId(), request);
 


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 뽀모도로 엔티티 focusCount 필드명 수정
- 뽀모도로의 집중 세션 개수라는 의미가 더 명확하도록 필드명을`focusCount` -> `focusSessionCount` 로 변경

<br/>

### ✅ 뽀모도로 집중 세션 개수를 함께 요청받도록 리팩토링
- 기존 고정된 값(1)을 지정했지만 클라이언트로부터 `focusSessionCount(집중 세션 개수)`도 함께 요청받아 뽀모도로 엔티티를 생성하도록 리팩토링
- `CreatePomodoroRequest` DTO에 `focusSessionCount` 필드 추가
- `Pomodoro` 엔티티를 생성하는 of() 메서드에서 `focusSessionCount` 필드에 고정된 값 삭제

<br/>

### ✅ 뽀모도로 관련 응답 정보에 focusSessionCount 필드 추가
- `PomodoroInfo` 클래스에 `focusSessionCount` 필드 추가
- 특정 데일리 목표 상세 조회 API 응답 정보인 `LoadDailyGoalDetailResponse` DTO `pomodoro` 필드에 `focusSessionCount` 필드 추가

<br/>

### ✅ 뽀모도로 집중 세션 개수 관련 테스트 코드 리팩토링 및 추가
- PomodoroService 단위 테스트에서 뽀모도로 엔티티를 생성하는 테스트 코드 리팩토링
- DailyGoalContorller 통합 테스트에서 뽀모도로 집중 시간, 집중 세션 개수 관련 예외 처리 테스트 코드 추가

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #57 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-