### PR TITLE
refactor: DailyGoal 상세 조회 StampName 응답 → title 필드 활용으로 구조 개선(#59)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionService.java
@@ -7,7 +7,6 @@ import com.ject.studytrip.mission.domain.policy.DailyMissionPolicy;
 import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
 import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
-import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,27 +44,7 @@ public class DailyMissionService {
         return dailyMissions;
     }
 
-    public List<DailyMission> getValidDailyMissionByIdsWithMissionAndStamp(
-            Long dailyGoalId, List<Long> dailyMissionIds) {
-        List<DailyMission> dailyMissions =
-                dailyMissionQueryRepository.findAllByIdsFetchJoinMissionAndStamp(dailyMissionIds);
-
-        DailyMissionPolicy.validateExistAll(dailyMissions, dailyMissionIds);
-        dailyMissions.forEach(
-                dailyMission -> {
-                    DailyMissionPolicy.validateBelongsToDailyGoal(dailyMission, dailyGoalId);
-                    DailyMissionPolicy.validateNotDeleted(dailyMission);
-                });
-
-        return dailyMissions;
-    }
-
     public List<DailyMission> getDailyMissionsByDailyGoal(Long dailyGoalId) {
         return dailyMissionQueryRepository.findAllByDailyGoalIdFetchJoinMission(dailyGoalId);
-    }
-
-    public void validateSelectedDailyMissions(
-            TripCategory tripCategory, List<DailyMission> dailyMissions) {
-        DailyMissionPolicy.validateCourseTripStampConsistency(tripCategory, dailyMissions);
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionService.java
@@ -121,8 +121,10 @@ public class MissionService {
         mission.updateCompleted();
     }
 
-    public void validateMissionBelongsToStamp(Long stampId, Mission mission) {
-        MissionPolicy.validateMissionBelongsToStamp(stampId, mission);
+    public void validateMissionsBelongsToStamp(Long stampId, List<Mission> missions) {
+        for (Mission mission : missions) {
+            MissionPolicy.validateMissionBelongsToStamp(stampId, mission);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ject/studytrip/mission/domain/error/DailyMissionErrorCode.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/error/DailyMissionErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 public enum DailyMissionErrorCode implements ErrorCode {
     // 400
     DAILY_MISSION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 데일리 미션입니다."),
-    COURSE_TRIP_STAMP_MISMATCH(HttpStatus.BAD_REQUEST, "코스형 여행의 데일리 미션들은 모두 동일한 스탬프여야 합니다."),
 
     // 403
     DAILY_MISSION_NOT_BELONG_TO_DAILY_GOAL(

--- a/src/main/java/com/ject/studytrip/mission/domain/policy/DailyMissionPolicy.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/policy/DailyMissionPolicy.java
@@ -3,10 +3,7 @@ package com.ject.studytrip.mission.domain.policy;
 import com.ject.studytrip.global.exception.CustomException;
 import com.ject.studytrip.mission.domain.error.DailyMissionErrorCode;
 import com.ject.studytrip.mission.domain.model.DailyMission;
-import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -26,19 +23,5 @@ public class DailyMissionPolicy {
     public static void validateNotDeleted(DailyMission dailyMission) {
         if (dailyMission.getDeletedAt() != null)
             throw new CustomException(DailyMissionErrorCode.DAILY_MISSION_ALREADY_DELETED);
-    }
-
-    public static void validateCourseTripStampConsistency(
-            TripCategory tripCategory, List<DailyMission> dailyMissions) {
-        if (tripCategory != TripCategory.COURSE) return;
-
-        Set<Long> stampIds =
-                dailyMissions.stream()
-                        .map(dailyMission -> dailyMission.getMission().getStamp().getId())
-                        .collect(Collectors.toSet());
-
-        if (stampIds.size() != 1) {
-            throw new CustomException(DailyMissionErrorCode.COURSE_TRIP_STAMP_MISMATCH);
-        }
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
@@ -5,6 +5,4 @@ import java.util.List;
 
 public interface DailyMissionQueryRepository {
     List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId);
-
-    List<DailyMission> findAllByIdsFetchJoinMissionAndStamp(List<Long> ids);
 }

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
@@ -4,7 +4,6 @@ import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.mission.domain.model.QDailyMission;
 import com.ject.studytrip.mission.domain.model.QMission;
 import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
-import com.ject.studytrip.stamp.domain.model.QStamp;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepo
     private final JPAQueryFactory queryFactory;
     private final QDailyMission dailyMission = QDailyMission.dailyMission;
     private final QMission mission = QMission.mission;
-    private final QStamp stamp = QStamp.stamp;
 
     @Override
     public List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId) {
@@ -25,18 +23,6 @@ public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepo
                 .join(dailyMission.mission, mission)
                 .fetchJoin()
                 .where(dailyMission.dailyGoal.id.eq(dailyGoalId), dailyMission.deletedAt.isNull())
-                .fetch();
-    }
-
-    @Override
-    public List<DailyMission> findAllByIdsFetchJoinMissionAndStamp(List<Long> ids) {
-        return queryFactory
-                .selectFrom(dailyMission)
-                .join(dailyMission.mission, mission)
-                .fetchJoin()
-                .join(mission.stamp, stamp)
-                .fetchJoin()
-                .where(dailyMission.id.in(ids))
                 .fetch();
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
@@ -128,7 +128,9 @@ public class StampService {
         stamps.forEach(StampPolicy::validateNotDeleted);
 
         if (tripCategory == TripCategory.COURSE) {
-            return getCourseStampName(stamps);
+            // 코스형 여행은 상위 검증에서 동일한 스탬프인지 검증이 완료된 상태이므로
+            // 스탬프 리스트에서 첫 번째 스탬프의 이름을 추출해도 안전
+            return stamps.get(0).getName();
         }
 
         return getExplorationStampName(stamps);
@@ -150,10 +152,6 @@ public class StampService {
         boolean exists =
                 stampQueryRepository.existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId);
         StampPolicy.validateAllCompleted(exists);
-    }
-
-    private String getCourseStampName(List<Stamp> stamps) {
-        return new HashSet<>(stamps).iterator().next().getName();
     }
 
     private String getExplorationStampName(List<Stamp> stamps) {

--- a/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
@@ -1,12 +1,9 @@
 package com.ject.studytrip.studylog.application.facade;
 
-import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.mission.application.service.DailyMissionService;
 import com.ject.studytrip.mission.application.service.MissionService;
 import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.pomodoro.application.service.PomodoroService;
-import com.ject.studytrip.stamp.application.service.StampService;
-import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.studylog.application.dto.StudyLogDetail;
 import com.ject.studytrip.studylog.application.dto.StudyLogInfo;
 import com.ject.studytrip.studylog.application.service.StudyLogDailyMissionService;
@@ -18,7 +15,6 @@ import com.ject.studytrip.trip.application.service.DailyGoalService;
 import com.ject.studytrip.trip.application.service.TripService;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import com.ject.studytrip.trip.domain.model.Trip;
-import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -30,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyLogFacade {
     private final TripService tripService;
-    private final StampService stampService;
     private final MissionService missionService;
     private final DailyGoalService dailyGoalService;
     private final DailyMissionService dailyMissionService;
@@ -45,16 +40,12 @@ public class StudyLogFacade {
         Trip trip = tripService.getValidTrip(memberId, tripId);
         DailyGoal dailyGoal = dailyGoalService.getValidDailyGoal(trip.getId(), dailyGoalId);
         List<DailyMission> selectedDailyMissions =
-                getValidatedDailyMissions(dailyGoal.getId(), request);
+                dailyMissionService.getValidDailyMissionsByIds(
+                        dailyGoal.getId(), request.selectedDailyMissionIds());
 
         // 2. 학습 로그 생성
         StudyLog studyLog =
-                createStudyLogWithTitle(
-                        trip.getMember(),
-                        dailyGoal,
-                        trip.getCategory(),
-                        selectedDailyMissions,
-                        request);
+                studyLogService.createStudyLog(trip.getMember(), dailyGoal, request.content());
 
         // 3. 뽀모도로 총 학습시간 업데이트
         pomodoroService.updateTotalFocusTime(dailyGoalId, request.totalFocusTimeInMinutes());
@@ -63,36 +54,6 @@ public class StudyLogFacade {
         createStudyLogDailyMissionsAndCompleteMissions(studyLog, selectedDailyMissions);
 
         return StudyLogInfo.from(studyLog);
-    }
-
-    private List<DailyMission> getValidatedDailyMissions(
-            Long dailyGoalId, CreateStudyLogRequest request) {
-        List<DailyMission> selectedDailyMissions =
-                dailyMissionService.getValidDailyMissionByIdsWithMissionAndStamp(
-                        dailyGoalId, request.selectedDailyMissionIds());
-        dailyMissionService.validateSelectedDailyMissions(
-                TripCategory.COURSE, selectedDailyMissions);
-        return selectedDailyMissions;
-    }
-
-    private StudyLog createStudyLogWithTitle(
-            Member member,
-            DailyGoal dailyGoal,
-            TripCategory tripCategory,
-            List<DailyMission> selectedDailyMissions,
-            CreateStudyLogRequest request) {
-        String title = determineTitleByStamps(tripCategory, selectedDailyMissions);
-        return studyLogService.createStudyLog(member, dailyGoal, title, request.content());
-    }
-
-    private String determineTitleByStamps(
-            TripCategory tripCategory, List<DailyMission> selectedDailyMissions) {
-        List<Stamp> stamps =
-                selectedDailyMissions.stream()
-                        .map(dailyMission -> dailyMission.getMission().getStamp())
-                        .toList();
-
-        return stampService.getStampNameByTripCategory(tripCategory, stamps);
     }
 
     private void createStudyLogDailyMissionsAndCompleteMissions(

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogService.java
@@ -23,9 +23,8 @@ public class StudyLogService {
         return studyLogQueryRepository.countActiveStudyLogsByMemberId(memberId);
     }
 
-    public StudyLog createStudyLog(
-            Member member, DailyGoal dailyGoal, String title, String content) {
-        StudyLog studyLog = StudyLogFactory.create(member, dailyGoal, title, content);
+    public StudyLog createStudyLog(Member member, DailyGoal dailyGoal, String content) {
+        StudyLog studyLog = StudyLogFactory.create(member, dailyGoal, content);
         return studyLogRepository.save(studyLog);
     }
 

--- a/src/main/java/com/ject/studytrip/studylog/domain/factory/StudyLogFactory.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/factory/StudyLogFactory.java
@@ -8,8 +8,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudyLogFactory {
-    public static StudyLog create(
-            Member member, DailyGoal dailyGoal, String title, String content) {
-        return StudyLog.of(member, dailyGoal, title, content);
+    public static StudyLog create(Member member, DailyGoal dailyGoal, String content) {
+        return StudyLog.of(member, dailyGoal, content);
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/model/StudyLog.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/model/StudyLog.java
@@ -31,11 +31,11 @@ public class StudyLog extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    public static StudyLog of(Member member, DailyGoal dailyGoal, String title, String content) {
+    public static StudyLog of(Member member, DailyGoal dailyGoal, String content) {
         return StudyLog.builder()
                 .member(member)
                 .dailyGoal(dailyGoal)
-                .title(title)
+                .title(dailyGoal.getTitle())
                 .content(content)
                 .build();
     }

--- a/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalInfo.java
+++ b/src/main/java/com/ject/studytrip/trip/application/dto/DailyGoalInfo.java
@@ -4,10 +4,16 @@ import com.ject.studytrip.global.util.DateUtil;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 
 public record DailyGoalInfo(
-        Long dailyGoalId, boolean completed, String createdAt, String updatedAt, String deletedAt) {
+        Long dailyGoalId,
+        String title,
+        boolean completed,
+        String createdAt,
+        String updatedAt,
+        String deletedAt) {
     public static DailyGoalInfo from(DailyGoal dailyGoal) {
         return new DailyGoalInfo(
                 dailyGoal.getId(),
+                dailyGoal.getTitle(),
                 dailyGoal.isCompleted(),
                 DateUtil.formatDateTime(dailyGoal.getCreatedAt()),
                 DateUtil.formatDateTime(dailyGoal.getUpdatedAt()),

--- a/src/main/java/com/ject/studytrip/trip/application/facade/DailyGoalFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/DailyGoalFacade.java
@@ -11,6 +11,7 @@ import com.ject.studytrip.pomodoro.application.dto.PomodoroInfo;
 import com.ject.studytrip.pomodoro.application.service.PomodoroService;
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 import com.ject.studytrip.stamp.application.service.StampService;
+import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.trip.application.dto.DailyGoalDetail;
 import com.ject.studytrip.trip.application.dto.DailyGoalInfo;
 import com.ject.studytrip.trip.application.service.DailyGoalService;
@@ -40,12 +41,13 @@ public class DailyGoalFacade {
     public DailyGoalInfo createDailyGoal(
             Long memberId, Long tripId, CreateDailyGoalRequest request) {
         Trip trip = getValidTripOwnedByMember(memberId, tripId);
-
-        DailyGoal dailyGoal = dailyGoalService.createDailyGoal(trip);
-
         List<Mission> missions = getValidMissionsByTripCategory(trip, request.missionIds());
-        dailyMissionService.createDailyMissions(dailyGoal, missions);
 
+        // 스탬프 이름을 추출해 title 설정
+        String title = determineTitleByStamps(trip.getCategory(), missions);
+        DailyGoal dailyGoal = dailyGoalService.createDailyGoal(trip, title);
+
+        dailyMissionService.createDailyMissions(dailyGoal, missions);
         pomodoroService.createPomodoro(dailyGoal, request.pomodoro());
 
         return DailyGoalInfo.from(dailyGoal);
@@ -128,11 +130,15 @@ public class DailyGoalFacade {
             Long currentStampId =
                     stampService.getFirstInCompleteStampForCourseTrip(trip.getId()).getId();
 
-            for (Mission mission : missions) {
-                missionService.validateMissionBelongsToStamp(currentStampId, mission);
-            }
+            missionService.validateMissionsBelongsToStamp(currentStampId, missions);
         }
 
         return missions;
+    }
+
+    private String determineTitleByStamps(TripCategory tripCategory, List<Mission> missions) {
+        List<Stamp> stamps = missions.stream().map(Mission::getStamp).toList();
+
+        return stampService.getStampNameByTripCategory(tripCategory, stamps);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalService.java
@@ -16,8 +16,8 @@ import org.springframework.stereotype.Service;
 public class DailyGoalService {
     public final DailyGoalRepository dailyGoalRepository;
 
-    public DailyGoal createDailyGoal(Trip trip) {
-        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+    public DailyGoal createDailyGoal(Trip trip, String title) {
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip, title);
         return dailyGoalRepository.save(dailyGoal);
     }
 

--- a/src/main/java/com/ject/studytrip/trip/domain/factory/DailyGoalFactory.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/factory/DailyGoalFactory.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DailyGoalFactory {
-    public static DailyGoal create(Trip trip) {
-        return DailyGoal.of(trip);
+    public static DailyGoal create(Trip trip, String title) {
+        return DailyGoal.of(trip, title);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/DailyGoal.java
@@ -20,10 +20,13 @@ public class DailyGoal extends BaseTimeEntity {
     @JoinColumn(name = "trip_id", nullable = false)
     private Trip trip;
 
+    @Column(nullable = false)
+    private String title;
+
     private boolean completed;
 
-    public static DailyGoal of(Trip trip) {
-        return DailyGoal.builder().trip(trip).completed(false).build();
+    public static DailyGoal of(Trip trip, String title) {
+        return DailyGoal.builder().trip(trip).title(title).completed(false).build();
     }
 
     public void updateDeletedAt() {

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadDailyGoalDetailResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public record LoadDailyGoalDetailResponse(
         @Schema(name = "데일리 목표 ID") Long dailyGoalId,
+        @Schema(name = "데일리 목표 제목(스탬프 이름)") String title,
         @Schema(name = "데일리 목표 완료 여부") boolean completed,
         @Schema(name = "뽀모도로 정보") DailyGoalPomodoroResponse pomodoro,
         @Schema(name = "수행할 데일리 미션 목록") List<DailyGoalMissionResponse> dailyMissions) {
@@ -18,6 +19,7 @@ public record LoadDailyGoalDetailResponse(
             List<DailyMissionInfo> dailyMissionInfos) {
         return new LoadDailyGoalDetailResponse(
                 dailyGoalInfo.dailyGoalId(),
+                dailyGoalInfo.title(),
                 dailyGoalInfo.completed(),
                 DailyGoalPomodoroResponse.of(pomodoroInfo),
                 dailyMissionInfos.stream().map(DailyGoalMissionResponse::of).toList());

--- a/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionServiceTest.java
@@ -2,7 +2,6 @@ package com.ject.studytrip.mission.application.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -13,7 +12,6 @@ import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.mission.domain.error.DailyMissionErrorCode;
 import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.mission.domain.model.Mission;
-import com.ject.studytrip.mission.domain.policy.DailyMissionPolicy;
 import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
 import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
 import com.ject.studytrip.mission.fixture.DailyMissionFixture;
@@ -178,62 +176,6 @@ public class DailyMissionServiceTest extends BaseUnitTest {
 
             // then
             assertThat(result.isEmpty()).isFalse();
-        }
-    }
-
-    @Nested
-    @DisplayName("validateSelectedMissions 메서드는")
-    class validateSelectedMissions {
-
-        @Test
-        @DisplayName("코스형 여행에서 선택한 DailyMission들이 모두 동일한 스탬프를 가질 경우 예외가 발생하지 않는다")
-        void shouldNotThrowExceptionWhenAllStampsAreSameInCourseTrip() {
-            // given
-            Stamp stamp = StampFixture.createStampWithId(1L, courseTrip, 1);
-            Mission mission1 = MissionFixture.createMissionWithId(1L, stamp, 1);
-            Mission mission2 = MissionFixture.createMissionWithId(2L, stamp, 2);
-
-            DailyGoal dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, courseTrip);
-
-            DailyMission dailyMission1 =
-                    DailyMissionFixture.createDailyMissionWithId(1L, mission1, dailyGoal);
-            DailyMission dailyMission2 =
-                    DailyMissionFixture.createDailyMissionWithId(2L, mission2, dailyGoal);
-
-            List<DailyMission> dailyMissions = List.of(dailyMission1, dailyMission2);
-
-            // when & then
-            assertDoesNotThrow(
-                    () ->
-                            DailyMissionPolicy.validateCourseTripStampConsistency(
-                                    TripCategory.COURSE, dailyMissions));
-        }
-
-        @Test
-        @DisplayName("코스형 여행에서 선택한 DailyMission 중 하나라도 다른 스탬프를 가지면 예외가 발생한다")
-        void shouldThrowExceptionWhenStampsAreDifferentInCourseTrip() {
-            // given
-            Stamp stamp1 = StampFixture.createStampWithId(1L, courseTrip, 1);
-            Stamp stamp2 = StampFixture.createStampWithId(2L, courseTrip, 2);
-            Mission mission1 = MissionFixture.createMissionWithId(1L, stamp1, 1);
-            Mission mission2 = MissionFixture.createMissionWithId(2L, stamp2, 1);
-
-            DailyGoal dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, courseTrip);
-
-            DailyMission dailyMission1 =
-                    DailyMissionFixture.createDailyMissionWithId(1L, mission1, dailyGoal);
-            DailyMission dailyMission2 =
-                    DailyMissionFixture.createDailyMissionWithId(2L, mission2, dailyGoal);
-
-            List<DailyMission> dailyMissions = List.of(dailyMission1, dailyMission2);
-
-            // when & then
-            assertThatThrownBy(
-                            () ->
-                                    DailyMissionPolicy.validateCourseTripStampConsistency(
-                                            TripCategory.COURSE, dailyMissions))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(DailyMissionErrorCode.COURSE_TRIP_STAMP_MISMATCH.getMessage());
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogServiceTest.java
@@ -87,7 +87,6 @@ class StudyLogServiceTest extends BaseUnitTest {
         void shouldReturnCreateStudyLog() {
             // given
             DailyGoal dailyGoal = DailyGoalFixture.createDailyGoalWithId(1L, courseTrip);
-            String title = "TEST Title";
             String content = "TEST content";
 
             given(studyLogRepository.save(any()))
@@ -99,13 +98,13 @@ class StudyLogServiceTest extends BaseUnitTest {
                             });
 
             // when
-            StudyLog result = studyLogService.createStudyLog(member, dailyGoal, title, content);
+            StudyLog result = studyLogService.createStudyLog(member, dailyGoal, content);
 
             // then
             assertThat(result.getId()).isEqualTo(1L);
             assertThat(result.getMember()).isEqualTo(member);
             assertThat(result.getDailyGoal()).isEqualTo(dailyGoal);
-            assertThat(result.getTitle()).isEqualTo(title);
+            assertThat(result.getTitle()).isEqualTo(dailyGoal.getTitle());
             assertThat(result.getContent()).isEqualTo(content);
         }
     }

--- a/src/test/java/com/ject/studytrip/studylog/fixture/StudyLogFixture.java
+++ b/src/test/java/com/ject/studytrip/studylog/fixture/StudyLogFixture.java
@@ -7,11 +7,10 @@ import com.ject.studytrip.trip.domain.model.DailyGoal;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class StudyLogFixture {
-    private static final String STUDY_LOG_TITLE = "TEST 학습 로그 제목";
     private static final String STUDY_LOG_CONTENT = "TEST 학습 로그 내용";
 
     public static StudyLog createStudyLog(Member member, DailyGoal dailyGoal) {
-        return StudyLogFactory.create(member, dailyGoal, STUDY_LOG_TITLE, STUDY_LOG_CONTENT);
+        return StudyLogFactory.create(member, dailyGoal, STUDY_LOG_CONTENT);
     }
 
     public static StudyLog createStudyLogWithId(Long id, Member member, DailyGoal dailyGoal) {

--- a/src/test/java/com/ject/studytrip/studylog/presentation/controller/StudyLogControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/presentation/controller/StudyLogControllerIntegrationTest.java
@@ -22,7 +22,6 @@ import com.ject.studytrip.mission.helper.MissionTestHelper;
 import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 import com.ject.studytrip.pomodoro.helper.PomodoroTestHelper;
-import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.helper.StampTestHelper;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
@@ -412,65 +411,6 @@ public class StudyLogControllerIntegrationTest extends BaseIntegrationTest {
                             jsonPath("$.status")
                                     .value(
                                             DailyMissionErrorCode.DAILY_MISSION_ALREADY_DELETED
-                                                    .getStatus()
-                                                    .value()));
-        }
-
-        @Test
-        @DisplayName("코스형 여행에서 선택된 데일리 미션들이 각각 속한 스탬프가 다를 경우 400 Bad Request를 반환한다")
-        void shouldReturnBadRequestWhenSelectedDailyMissionsHaveDifferentStampsInCourseTrip()
-                throws Exception {
-            // given
-            Stamp newStamp = stampTestHelper.saveStamp(courseTrip, 2);
-            Mission newMission = missionTestHelper.saveMission(newStamp, 1);
-            DailyMission newDailyMission =
-                    dailyMissionTestHelper.saveDailyMission(newMission, dailyGoal);
-            CreateStudyLogRequest request =
-                    fixture.withSelectedDailyMissionIds(
-                                    List.of(dailyMission.getId(), newDailyMission.getId()))
-                            .build();
-
-            // when
-            ResultActions resultActions =
-                    getResultActions(token, courseTrip.getId(), dailyGoal.getId(), request);
-
-            // then
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(
-                            jsonPath("$.status")
-                                    .value(
-                                            DailyMissionErrorCode.COURSE_TRIP_STAMP_MISMATCH
-                                                    .getStatus()
-                                                    .value()));
-        }
-
-        @Test
-        @DisplayName("삭제된 스탬프가 포함되어있을 경우 400 Bad Request를 반환한다")
-        void shouldReturnBadRequestWhenStampIsDeleted() throws Exception {
-            // given
-            Trip trip = tripTestHelper.saveTrip(member, TripCategory.COURSE);
-            Stamp deletedStamp = stampTestHelper.saveDeletedStamp(trip, 1);
-            Mission mission = missionTestHelper.saveMission(deletedStamp, 1);
-            DailyGoal dailyGoal = dailyGoalTestHelper.saveDailyGoal(trip);
-            DailyMission dailyMission = dailyMissionTestHelper.saveDailyMission(mission, dailyGoal);
-
-            CreateStudyLogRequest request =
-                    fixture.withSelectedDailyMissionIds(List.of(dailyMission.getId())).build();
-
-            // when
-            ResultActions resultActions =
-                    getResultActions(token, trip.getId(), dailyGoal.getId(), request);
-
-            // then
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(
-                            jsonPath("$.status")
-                                    .value(
-                                            StampErrorCode.STAMP_ALREADY_DELETED
                                                     .getStatus()
                                                     .value()));
         }

--- a/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalServiceTest.java
@@ -49,10 +49,11 @@ public class DailyGoalServiceTest extends BaseUnitTest {
         @DisplayName("여행에 속한 데일리 목표를 생성하고 저장된 값을 반환한다")
         void shouldCreateAndSaveDailyGoal() {
             // given
+            String title = "TEST TITLE";
             given(dailyGoalRepository.save(any())).willReturn(dailyGoal);
 
             // when
-            DailyGoal result = dailyGoalService.createDailyGoal(trip);
+            DailyGoal result = dailyGoalService.createDailyGoal(trip, title);
 
             // then
             assertThat(result).isNotNull();

--- a/src/test/java/com/ject/studytrip/trip/fixture/DailyGoalFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/DailyGoalFixture.java
@@ -6,19 +6,21 @@ import com.ject.studytrip.trip.domain.model.Trip;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class DailyGoalFixture {
+    private static final String DEFAULT_TITLE = "TEST TITLE";
+
     public static DailyGoal createDailyGoal(Trip trip) {
-        return DailyGoalFactory.create(trip);
+        return DailyGoalFactory.create(trip, DEFAULT_TITLE);
     }
 
     public static DailyGoal createDailyGoalWithId(Long id, Trip trip) {
-        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip, DEFAULT_TITLE);
         ReflectionTestUtils.setField(dailyGoal, "id", id);
 
         return dailyGoal;
     }
 
     public static DailyGoal createDeletedDailyGoal(Trip trip) {
-        DailyGoal dailyGoal = DailyGoalFactory.create(trip);
+        DailyGoal dailyGoal = DailyGoalFactory.create(trip, DEFAULT_TITLE);
         dailyGoal.updateDeletedAt();
 
         return dailyGoal;


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ DailyGoal title 필드 추가
- `DailyGoal` 엔티티에 `title` 필드를 추가했습니다.
- 특정 데일리 목표 상세 조회 시, 여행 카테고리별 특정 스탬프의 이름을 함께 응답해야하는 요구사항을 반영했습니다.
- 특정 데일리 목표를 조회할 때마다 매번 스탬프 이름을 추출해 응답하면 반복된 계산 로직이 발생하게 되고, 이를 방지하고자 `DailyGoal` 엔티티에 `title` 필드를 두어 관리하고 `DailyGoal` 생성 시 최초 1회만 스탬프 이름을 추출해 `title`로 지정하도록 구조를 구성했습니다.

<br/>

### ✅ StudyLog 생성 로직 리팩토링
- 기존에는 `StudyLog` 엔티티를 생성할 때 여행 카테고리별 특정 스탬프의 이름을 추출해 `StudyLog.title` 필드에 저장했지만, `DailyGoal` 엔티티에 `title` 필드를 관리하게 되면서 스탬프 이름 추출과 저장 책임은 `DailyGoal`에 넘기고 `StudyLog.title`에는 `DailyGoal.title` 값을 저장하도록 리팩토링했습니다.
- 이에 따라 불필요해진 `DailyMission` 기반 Mission 및 Stamp 조회/검증 로직, 쿼리 메서드, 에러 코드를 제거했습니다.

<br/>

### ✅ 테스트 코드 수정
- `DailyGoal.title` 리팩토링에 따라 관련 테스트 코드를 수정했습니다.
- `StudyLog` 생성 로직 변경에 따라 통합/단위 테스트 및 Fixture/Helper 클래스도 수정했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #59 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-