### PR TITLE
refactor: 뽀모도로 총 집중 시간 초단위로 변경(#61)

### DIFF
--- a/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroService.java
@@ -40,8 +40,8 @@ public class PomodoroService {
         return pomodoro;
     }
 
-    public void updateTotalFocusTime(Long dailyGoalId, int totalFocusTimeInMinutes) {
-        PomodoroPolicy.validateTotalFocusTimeNotNegative(totalFocusTimeInMinutes);
+    public void updateTotalFocusTime(Long dailyGoalId, int totalFocusTimeInSeconds) {
+        PomodoroPolicy.validateTotalFocusTimeNotNegative(totalFocusTimeInSeconds);
 
         Pomodoro pomodoro =
                 pomodoroRepository
@@ -50,7 +50,6 @@ public class PomodoroService {
                                 () -> new CustomException(PomodoroErrorCode.POMODORO_NOT_FOUND));
         PomodoroPolicy.validateNotDeleted(pomodoro);
 
-        int totalFocusTimeInSeconds = totalFocusTimeInMinutes * 60;
         pomodoro.updateTotalFocusTimeInSeconds(totalFocusTimeInSeconds);
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/presentation/dto/request/CreatePomodoroRequest.java
@@ -1,7 +1,10 @@
 package com.ject.studytrip.pomodoro.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 
 public record CreatePomodoroRequest(
-        @Min(value = 1, message = "뽀모도로 최소 집중 시간은 1분입니다.") int focusDurationInMinute,
-        @Min(value = 1, message = "뽀모도로 최소 집중 세션 개수는 1개입니다.") int focusSessionCount) {}
+        @Schema(description = "집중 시간(분)") @Min(value = 1, message = "뽀모도로 최소 집중 시간은 1분입니다.")
+                int focusDurationInMinute,
+        @Schema(description = "집중 세션 개수") @Min(value = 1, message = "뽀모도로 최소 집중 세션 개수는 1개입니다.")
+                int focusSessionCount) {}

--- a/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
@@ -48,7 +48,7 @@ public class StudyLogFacade {
                 studyLogService.createStudyLog(trip.getMember(), dailyGoal, request.content());
 
         // 3. 뽀모도로 총 학습시간 업데이트
-        pomodoroService.updateTotalFocusTime(dailyGoalId, request.totalFocusTimeInMinutes());
+        pomodoroService.updateTotalFocusTime(dailyGoalId, request.totalFocusTimeInSeconds());
 
         // 4. 연관 데이터 생성 및 미션 완료 처리
         createStudyLogDailyMissionsAndCompleteMissions(studyLog, selectedDailyMissions);

--- a/src/main/java/com/ject/studytrip/studylog/presentation/dto/request/CreateStudyLogRequest.java
+++ b/src/main/java/com/ject/studytrip/studylog/presentation/dto/request/CreateStudyLogRequest.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record CreateStudyLogRequest(
-        @Schema(description = "뽀모도로 총 집중시간(분)") @Min(value = 0, message = "총 집중시간(분)은 음수일 수 없습니다.")
-                int totalFocusTimeInMinutes,
+        @Schema(description = "뽀모도로 총 집중시간(초)") @Min(value = 0, message = "총 집중시간(초)은 음수일 수 없습니다.")
+                int totalFocusTimeInSeconds,
         @Schema(description = "선택한 데일리 미션 ID 목록")
                 @NotEmpty(message = "학습로그를 작성할 데일리 미션 목록은 필수 요청 값입니다.")
                 List<Long> selectedDailyMissionIds,

--- a/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroServiceTest.java
@@ -135,29 +135,28 @@ public class PomodoroServiceTest extends BaseUnitTest {
         @DisplayName("유효한 데일리 목표 ID와 총 학습시간으로 뽀모도로의 총 학습시간을 업데이트한다")
         void shouldUpdateTotalFocusTime() {
             // given
-            int totalFocusTimeInMinutes = 120;
+            int totalFocusTimeInSeconds = 120;
             given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
                     .willReturn(Optional.of(pomodoro));
 
             // when
-            pomodoroService.updateTotalFocusTime(dailyGoal.getId(), totalFocusTimeInMinutes);
+            pomodoroService.updateTotalFocusTime(dailyGoal.getId(), totalFocusTimeInSeconds);
 
             // then
-            assertThat(pomodoro.getTotalFocusTimeInSeconds())
-                    .isEqualTo(totalFocusTimeInMinutes * 60);
+            assertThat(pomodoro.getTotalFocusTimeInSeconds()).isEqualTo(totalFocusTimeInSeconds);
         }
 
         @Test
         @DisplayName("뽀모도로 총 집중시간(분)이 음수일 경우 예외가 발생한다")
         void shouldThrowExceptionWhenTotalFocusTimeIsNegative() {
             // given
-            int totalFocusTimeInMinutes = -30;
+            int totalFocusTimeInSeconds = -30;
 
             // when & then
             assertThatThrownBy(
                             () ->
                                     pomodoroService.updateTotalFocusTime(
-                                            dailyGoal.getId(), totalFocusTimeInMinutes))
+                                            dailyGoal.getId(), totalFocusTimeInSeconds))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PomodoroErrorCode.POMODORO_NEGATIVE_FOCUS_TIME.getMessage());
         }
@@ -166,7 +165,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
         @DisplayName("뽀모도로가 존재하지 않으면 예외가 발생한다")
         void shouldThrowExceptionWhenPomodoroNotFound() {
             // given
-            int totalFocusTimeInMinutes = 60;
+            int totalFocusTimeInSeconds = 60;
             given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
                     .willReturn(Optional.empty());
 
@@ -174,7 +173,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
             assertThatThrownBy(
                             () ->
                                     pomodoroService.updateTotalFocusTime(
-                                            dailyGoal.getId(), totalFocusTimeInMinutes))
+                                            dailyGoal.getId(), totalFocusTimeInSeconds))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PomodoroErrorCode.POMODORO_NOT_FOUND.getMessage());
         }
@@ -183,7 +182,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 뽀모도로일 경우 예외가 발생한다")
         void shouldThrowExceptionWhenPomodoroIsDeleted() {
             // given
-            int totalFocusTimeInMinutes = 60;
+            int totalFocusTimeInSeconds = 60;
             pomodoro.updateDeletedAt();
             given(pomodoroRepository.findByDailyGoalId(dailyGoal.getId()))
                     .willReturn(Optional.of(pomodoro));
@@ -192,7 +191,7 @@ public class PomodoroServiceTest extends BaseUnitTest {
             assertThatThrownBy(
                             () ->
                                     pomodoroService.updateTotalFocusTime(
-                                            dailyGoal.getId(), totalFocusTimeInMinutes))
+                                            dailyGoal.getId(), totalFocusTimeInSeconds))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PomodoroErrorCode.POMODORO_ALREADY_DELETED.getMessage());
         }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ Pomodoro 총 집중 시간 초단위로 변경
- 요구사항에 따라 Pomodoro 생성 혹은 조회 시 집중 시간은 분단위로, StudyLog 생성 혹은 조회 시 총 집중 시간은 초단위를 반영했습니다.
- 요구사항에 따라 CreateStudyLogRequest DTO에서 총 집중 시간 요청 시 분 -> 초단위로 수정했습니다.
- 이에 따라 관련된 PomodoroService.updateTotalFocusTime() 메서드도 리팩토링했습니다.

### ✅ 테스트 코드
- PomodoroService 단위 테스트의 totalFocusTimeInMinute -> totalFocusTimeInSeconds로 변경했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #61 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-