### PR TITLE
fix: 스탬프 완료 로직 버그 수정 (#79)

### DIFF
--- a/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
@@ -76,6 +76,7 @@ public class StampFacade {
                 StampInfo.from(stamp), missions.stream().map(MissionInfo::from).toList());
     }
 
+    @Transactional
     public void completeStamp(Long memberId, Long tripId, Long stampId) {
         Trip trip = tripService.getValidTrip(memberId, tripId);
         Stamp stamp = stampService.getValidStamp(trip.getId(), stampId);

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampService.java
@@ -137,7 +137,6 @@ public class StampService {
         return getExplorationStampName(stamps);
     }
 
-    @Transactional
     public void completeStamp(Stamp stamp) {
         StampPolicy.validateCompleted(stamp);
 


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 스탬프 완료 로직 버그 해결
- 스탬프 완료 요청 시, 200 OK 응답은 잘 되지만 `Stamp` 엔티티의 `completed` 필드가 `false -> true`로 업데이트되지 않는 버그가 발생했습니다.
- 기존 `StampService.completeStamp()`에 트랜잭션이 적용되어 있는데, 트랜잭션 밖에서 조회된 `Stamp` 엔티티를 매개변수로 전달받아 업데이트를 수행하고 있었습니다.
- 실행 시 전달된 `Stamp`는 현재 영속성 컨텍스트에서 관리되지 않는 상태라 더티 체킹이 정상적으로 동작하지 않았습니다. 
- `StampService.completeStamp()`의 트랜잭션을 제거하고, 상위 로직인 `StampFacade.completeStamp()`에 트랜잭션을 적용해 **하나의(동일한) 트랜잭션 내에서 동일한 영속성 컨텍스트로 엔티티가 관리**되도록 수정했습니다.
- `StampService.completeStamp()` 트랜잭션을 유지하고, 매개변수로 **ID**를 받아 해당 메서드에서 직접 엔티티를 조회하고 업데이트하는 방법도 있었지만 코드의 수정과 변경 범위를 생각해 위의 방법을 사용했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #79 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-