### PR TITLE
fix: 캐싱된 목록 데이터 역직렬화 오류 수정(JSON 타입으로 통일) (#81)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/application/dto/MissionsInfo.java
+++ b/src/main/java/com/ject/studytrip/mission/application/dto/MissionsInfo.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.mission.application.dto;
+
+import java.util.List;
+
+public record MissionsInfo(List<MissionInfo> missionInfos) {
+    public static MissionsInfo of(List<MissionInfo> missionInfos) {
+        return new MissionsInfo(missionInfos);
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/application/facade/MissionFacade.java
+++ b/src/main/java/com/ject/studytrip/mission/application/facade/MissionFacade.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.mission.application.facade;
 import static com.ject.studytrip.global.common.constants.CacheNameConstants.*;
 
 import com.ject.studytrip.mission.application.dto.MissionInfo;
+import com.ject.studytrip.mission.application.dto.MissionsInfo;
 import com.ject.studytrip.mission.application.service.MissionCommandService;
 import com.ject.studytrip.mission.application.service.MissionQueryService;
 import com.ject.studytrip.mission.domain.model.Mission;
@@ -97,11 +98,11 @@ public class MissionFacade {
             key =
                     "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).missions(#memberId, #tripId, #stampId)")
     @Transactional(readOnly = true)
-    public List<MissionInfo> getMissionsByStamp(Long memberId, Long tripId, Long stampId) {
+    public MissionsInfo getMissionsByStamp(Long memberId, Long tripId, Long stampId) {
         Stamp stamp = getValidStampFromTripOwnedByMember(memberId, tripId, stampId);
         List<Mission> missions = missionQueryService.getMissionsByStampId(stamp.getId());
 
-        return missions.stream().map(MissionInfo::from).toList();
+        return MissionsInfo.of(missions.stream().map(MissionInfo::from).toList());
     }
 
     private Stamp getValidStampFromTripOwnedByMember(Long memberId, Long tripId, Long stampId) {

--- a/src/main/java/com/ject/studytrip/mission/presentation/controller/MissionController.java
+++ b/src/main/java/com/ject/studytrip/mission/presentation/controller/MissionController.java
@@ -2,6 +2,7 @@ package com.ject.studytrip.mission.presentation.controller;
 
 import com.ject.studytrip.global.common.response.StandardResponse;
 import com.ject.studytrip.mission.application.dto.MissionInfo;
+import com.ject.studytrip.mission.application.dto.MissionsInfo;
 import com.ject.studytrip.mission.application.facade.MissionFacade;
 import com.ject.studytrip.mission.presentation.dto.request.CreateMissionRequest;
 import com.ject.studytrip.mission.presentation.dto.request.UpdateMissionRequest;
@@ -77,10 +78,10 @@ public class MissionController {
             @AuthenticationPrincipal String memberId,
             @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
             @PathVariable @NotNull(message = "스탬프 ID는 필수 요청 파라미터입니다.") Long stampId) {
-        List<MissionInfo> results =
+        MissionsInfo results =
                 missionFacade.getMissionsByStamp(Long.valueOf(memberId), tripId, stampId);
         List<LoadMissionInfoResponse> responses =
-                results.stream().map(LoadMissionInfoResponse::of).toList();
+                results.missionInfos().stream().map(LoadMissionInfoResponse::of).toList();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(StandardResponse.success(HttpStatus.OK.value(), responses));

--- a/src/main/java/com/ject/studytrip/stamp/application/dto/StampsInfo.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/dto/StampsInfo.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.stamp.application.dto;
+
+import java.util.List;
+
+public record StampsInfo(List<StampInfo> stampsInfos) {
+    public static StampsInfo of(List<StampInfo> stampsInfos) {
+        return new StampsInfo(stampsInfos);
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
@@ -8,6 +8,7 @@ import com.ject.studytrip.mission.application.service.MissionQueryService;
 import com.ject.studytrip.mission.domain.model.Mission;
 import com.ject.studytrip.stamp.application.dto.StampDetail;
 import com.ject.studytrip.stamp.application.dto.StampInfo;
+import com.ject.studytrip.stamp.application.dto.StampsInfo;
 import com.ject.studytrip.stamp.application.service.StampCommandService;
 import com.ject.studytrip.stamp.application.service.StampQueryService;
 import com.ject.studytrip.stamp.domain.model.Stamp;
@@ -119,11 +120,11 @@ public class StampFacade {
             key =
                     "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamps(#memberId, #tripId)")
     @Transactional(readOnly = true)
-    public List<StampInfo> getStampsByTrip(Long memberId, Long tripId) {
+    public StampsInfo getStampsByTrip(Long memberId, Long tripId) {
         Trip trip = tripQueryService.getValidTrip(memberId, tripId);
         List<Stamp> stamps = stampQueryService.getStampsByTripId(trip.getId());
 
-        return stamps.stream().map(StampInfo::from).toList();
+        return StampsInfo.of(stamps.stream().map(StampInfo::from).toList());
     }
 
     @Cacheable(

--- a/src/main/java/com/ject/studytrip/stamp/presentation/controller/StampController.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/controller/StampController.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.stamp.presentation.controller;
 import com.ject.studytrip.global.common.response.StandardResponse;
 import com.ject.studytrip.stamp.application.dto.StampDetail;
 import com.ject.studytrip.stamp.application.dto.StampInfo;
+import com.ject.studytrip.stamp.application.dto.StampsInfo;
 import com.ject.studytrip.stamp.application.facade.StampFacade;
 import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
 import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
@@ -85,9 +86,9 @@ public class StampController {
     @GetMapping("/{tripId}/stamps")
     public ResponseEntity<StandardResponse> loadStampsByTrip(
             @AuthenticationPrincipal String memberId, @PathVariable Long tripId) {
-        List<StampInfo> result = stampFacade.getStampsByTrip(Long.valueOf(memberId), tripId);
+        StampsInfo result = stampFacade.getStampsByTrip(Long.valueOf(memberId), tripId);
         List<LoadStampInfoResponse> response =
-                result.stream().map(LoadStampInfoResponse::of).toList();
+                result.stampsInfos().stream().map(LoadStampInfoResponse::of).toList();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(StandardResponse.success(HttpStatus.OK.value(), response));

--- a/src/main/java/com/ject/studytrip/studylog/application/dto/StudyLogSliceInfo.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/dto/StudyLogSliceInfo.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.studylog.application.dto;
+
+import java.util.List;
+
+public record StudyLogSliceInfo(List<StudyLogDetail> studyLogDetails, boolean hasNext) {
+    public static StudyLogSliceInfo of(List<StudyLogDetail> studyLogDetails, boolean hasNext) {
+        return new StudyLogSliceInfo(studyLogDetails, hasNext);
+    }
+}

--- a/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
@@ -14,6 +14,7 @@ import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 import com.ject.studytrip.studylog.application.dto.PresignedStudyLogImageInfo;
 import com.ject.studytrip.studylog.application.dto.StudyLogDetail;
 import com.ject.studytrip.studylog.application.dto.StudyLogInfo;
+import com.ject.studytrip.studylog.application.dto.StudyLogSliceInfo;
 import com.ject.studytrip.studylog.application.service.*;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.domain.model.StudyLogDailyMission;
@@ -30,7 +31,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,8 +88,7 @@ public class StudyLogFacade {
             key =
                     "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).studyLogs(#memberId, #tripId, #page, #size)")
     @Transactional(readOnly = true)
-    public Slice<StudyLogDetail> getStudyLogsByTrip(
-            Long memberId, Long tripId, int page, int size) {
+    public StudyLogSliceInfo getStudyLogsByTrip(Long memberId, Long tripId, int page, int size) {
         // 1. 유효성 검증 및 엔티티 조회
         Trip trip = tripQueryService.getValidTrip(memberId, tripId);
 
@@ -133,7 +132,7 @@ public class StudyLogFacade {
                 dailyMission -> missionCommandService.completeMission(dailyMission.getMission()));
     }
 
-    private Slice<StudyLogDetail> buildStudyLogDetailsSlice(Slice<StudyLog> studyLogSlice) {
+    private StudyLogSliceInfo buildStudyLogDetailsSlice(Slice<StudyLog> studyLogSlice) {
         List<Long> studyLogIds = studyLogSlice.getContent().stream().map(StudyLog::getId).toList();
 
         // 학습 로그별 학습 로그 데일리 미션 목록 그룹화
@@ -150,7 +149,6 @@ public class StudyLogFacade {
                                                 groupedStudyLogDailyMissions.get(studyLog.getId())))
                         .toList();
 
-        return new SliceImpl<>(
-                studyLogDetails, studyLogSlice.getPageable(), studyLogSlice.hasNext());
+        return StudyLogSliceInfo.of(studyLogDetails, studyLogSlice.hasNext());
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/presentation/controller/StudyLogController.java
+++ b/src/main/java/com/ject/studytrip/studylog/presentation/controller/StudyLogController.java
@@ -2,8 +2,8 @@ package com.ject.studytrip.studylog.presentation.controller;
 
 import com.ject.studytrip.global.common.response.StandardResponse;
 import com.ject.studytrip.studylog.application.dto.PresignedStudyLogImageInfo;
-import com.ject.studytrip.studylog.application.dto.StudyLogDetail;
 import com.ject.studytrip.studylog.application.dto.StudyLogInfo;
+import com.ject.studytrip.studylog.application.dto.StudyLogSliceInfo;
 import com.ject.studytrip.studylog.application.facade.StudyLogFacade;
 import com.ject.studytrip.studylog.presentation.dto.request.ConfirmStudyLogImageRequest;
 import com.ject.studytrip.studylog.presentation.dto.request.CreateStudyLogRequest;
@@ -18,7 +18,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -57,13 +56,15 @@ public class StudyLogController {
             @PathVariable @NotNull(message = "여행 ID는 필수 요청 파라미터입니다.") Long tripId,
             @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
             @RequestParam(name = "size", defaultValue = "5") @Min(1) @Max(10) int size) {
-        Slice<StudyLogDetail> result =
+        StudyLogSliceInfo result =
                 studyLogFacade.getStudyLogsByTrip(Long.valueOf(memberId), tripId, page, size);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(
                         StandardResponse.success(
-                                HttpStatus.OK.value(), LoadStudyLogsSliceResponse.of(result)));
+                                HttpStatus.OK.value(),
+                                LoadStudyLogsSliceResponse.of(
+                                        result.studyLogDetails(), result.hasNext())));
     }
 
     @Operation(

--- a/src/main/java/com/ject/studytrip/studylog/presentation/dto/response/LoadStudyLogsSliceResponse.java
+++ b/src/main/java/com/ject/studytrip/studylog/presentation/dto/response/LoadStudyLogsSliceResponse.java
@@ -6,21 +6,21 @@ import com.ject.studytrip.studylog.application.dto.StudyLogDetail;
 import com.ject.studytrip.studylog.application.dto.StudyLogInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import org.springframework.data.domain.Slice;
 
 public record LoadStudyLogsSliceResponse(
         @Schema(description = "학습 로그 목록") List<StudyLogResponse> studyLogs,
         @Schema(description = "다음 데이터 존재 여부") boolean hasNext) {
-    public static LoadStudyLogsSliceResponse of(Slice<StudyLogDetail> results) {
+    public static LoadStudyLogsSliceResponse of(
+            List<StudyLogDetail> studyLogDetails, boolean hasNext) {
         return new LoadStudyLogsSliceResponse(
-                results.getContent().stream()
+                studyLogDetails.stream()
                         .map(
                                 result ->
                                         StudyLogResponse.of(
                                                 result.studyLogInfo(),
                                                 result.studyLogDailyMissionInfos()))
                         .toList(),
-                results.hasNext());
+                hasNext);
     }
 
     private record StudyLogResponse(

--- a/src/main/java/com/ject/studytrip/trip/application/dto/TripSliceInfo.java
+++ b/src/main/java/com/ject/studytrip/trip/application/dto/TripSliceInfo.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.trip.application.dto;
+
+import java.util.List;
+
+public record TripSliceInfo(List<TripInfo> tripInfos, boolean hasNext) {
+    public static TripSliceInfo of(List<TripInfo> tripInfos, boolean hasNext) {
+        return new TripSliceInfo(tripInfos, hasNext);
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
@@ -11,6 +11,7 @@ import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.trip.application.dto.TripCategoryInfo;
 import com.ject.studytrip.trip.application.dto.TripDetail;
 import com.ject.studytrip.trip.application.dto.TripInfo;
+import com.ject.studytrip.trip.application.dto.TripSliceInfo;
 import com.ject.studytrip.trip.application.service.TripCommandService;
 import com.ject.studytrip.trip.application.service.TripQueryService;
 import com.ject.studytrip.trip.domain.model.Trip;
@@ -27,7 +28,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,7 +106,7 @@ public class TripFacade {
             key =
                     "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trips(#memberId, #page, #size)")
     @Transactional(readOnly = true)
-    public Slice<TripInfo> getTripsByMember(Long memberId, int page, int size) {
+    public TripSliceInfo getTripsByMember(Long memberId, int page, int size) {
         Slice<Trip> tripSlice = tripQueryService.getTripsSliceByMemberId(memberId, page, size);
 
         List<TripInfo> tripInfos =
@@ -126,7 +126,7 @@ public class TripFacade {
                                         Comparator.nullsLast(Comparator.naturalOrder())))
                         .toList();
 
-        return new SliceImpl<>(tripInfos, tripSlice.getPageable(), tripSlice.hasNext());
+        return TripSliceInfo.of(tripInfos, tripSlice.hasNext());
     }
 
     @Cacheable(

--- a/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
@@ -4,6 +4,7 @@ import com.ject.studytrip.global.common.response.StandardResponse;
 import com.ject.studytrip.trip.application.dto.TripCategoryInfo;
 import com.ject.studytrip.trip.application.dto.TripDetail;
 import com.ject.studytrip.trip.application.dto.TripInfo;
+import com.ject.studytrip.trip.application.dto.TripSliceInfo;
 import com.ject.studytrip.trip.application.facade.TripFacade;
 import com.ject.studytrip.trip.presentation.dto.request.CreateTripRequest;
 import com.ject.studytrip.trip.presentation.dto.request.UpdateTripRequest;
@@ -16,7 +17,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -89,13 +89,13 @@ public class TripController {
             @AuthenticationPrincipal String memberId,
             @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
             @RequestParam(name = "size", defaultValue = "5") @Min(1) @Max(10) int size) {
-        Slice<TripInfo> result = tripFacade.getTripsByMember(Long.valueOf(memberId), page, size);
+        TripSliceInfo result = tripFacade.getTripsByMember(Long.valueOf(memberId), page, size);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(
                         StandardResponse.success(
                                 HttpStatus.OK.value(),
-                                LoadTripsSliceResponse.of(result.getContent(), result.hasNext())));
+                                LoadTripsSliceResponse.of(result.tripInfos(), result.hasNext())));
     }
 
     @Operation(summary = "여행 상세 조회", description = "특정 여행을 조회하는 API 입니다.")


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ Slice/List 타입 반환 -> DTO 반환으로 변경
- `@Cacheable`이 적용된 메서드 중 목록 데이터를 캐싱하는 메서드에서 역직렬화에 실패하는 오류가 발생했습니다.
```
[nio-8080-exec-3] c.j.s.g.e.h.GlobalExceptionHandler       : Internal Server Error : Could not read JSON:Unexpected token (START_OBJECT), expected VALUE_STRING: need String, Number of Boolean value that contains type id (for subtype of java.lang.Object)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2]
org.springframework.data.redis.serializer.SerializationException: Could not read JSON:Unexpected token (START_OBJECT), expected VALUE_STRING: need String, Number of Boolean value that contains type id (for subtype of java.lang.Object)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2]
```
- 목록 반환을 Slice/List -> 래퍼 DTO로 전환해 반환하도록 해 캐시 값 타입을 일치시켰습니다. (`TripSliceInfo`, `StudyLogSliceInfo`, `StampsInfo`, `MissionsInfo`)
- 모두 DTO 타입으로 변환하고 로컬에서 테스트를 수행한 결과, 여러번 조회 요청에도 오류없이 성공하는 걸 확인했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #81 

<br/>

## 🔍 참고사항(선택)
- 지금은 우선 빠르게 변경 사항을 적용시키고, 추후 발생했던 역직렬화에 대한 예외와 원인을 좀 더 세세히 분석해 해당 PR에 적어두겠습니다.


<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-