### PR TITLE
fix: 스탬프/미션 변경 시 여행 상세 조회 캐시 무효화 누락 수정(#85)

### DIFF
--- a/src/main/java/com/ject/studytrip/mission/application/facade/MissionFacade.java
+++ b/src/main/java/com/ject/studytrip/mission/application/facade/MissionFacade.java
@@ -41,7 +41,12 @@ public class MissionFacade {
                 @CacheEvict(
                         cacheNames = STAMP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)"),
+                @CacheEvict(
+                        cacheNames = TRIP,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public MissionInfo createMission(
@@ -62,7 +67,12 @@ public class MissionFacade {
                 @CacheEvict(
                         cacheNames = STAMP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)"),
+                @CacheEvict(
+                        cacheNames = TRIP,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void updateMissionNameIfPresent(
@@ -86,7 +96,12 @@ public class MissionFacade {
                 @CacheEvict(
                         cacheNames = STAMP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)"),
+                @CacheEvict(
+                        cacheNames = TRIP,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void deleteMission(Long memberId, Long tripId, Long stampId, Long missionId) {

--- a/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
@@ -46,7 +46,8 @@ public class StampFacade {
                 @CacheEvict(
                         cacheNames = TRIP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public StampInfo createStamp(Long memberId, Long tripId, CreateStampRequest request) {
@@ -66,7 +67,12 @@ public class StampFacade {
                 @CacheEvict(
                         cacheNames = STAMP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamp(#memberId, #tripId, #stampId)"),
+                @CacheEvict(
+                        cacheNames = TRIP,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void updateStamp(Long memberId, Long tripId, Long stampId, UpdateStampRequest request) {
@@ -82,7 +88,12 @@ public class StampFacade {
                         cacheNames = STAMPS,
                         key =
                                 "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).stamps(#memberId, #tripId)"),
-                @CacheEvict(cacheNames = STAMP, allEntries = true)
+                @CacheEvict(cacheNames = STAMP, allEntries = true),
+                @CacheEvict(
+                        cacheNames = TRIP,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void updateStampOrders(Long memberId, Long tripId, UpdateStampOrderRequest request) {
@@ -104,7 +115,8 @@ public class StampFacade {
                 @CacheEvict(
                         cacheNames = TRIP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void deleteStamp(Long memberId, Long tripId, Long stampId) {
@@ -154,7 +166,8 @@ public class StampFacade {
                 @CacheEvict(
                         cacheNames = TRIP,
                         key =
-                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)")
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).trip(#memberId, #tripId)"),
+                @CacheEvict(cacheNames = TRIPS, allEntries = true)
             })
     @Transactional
     public void completeStamp(Long memberId, Long tripId, Long stampId) {


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

- `StampFacade` 등록/수정/삭제/완료 메서드에 `@CacheEvict(cacheNames = TRIP)`, `@CacheEvict(cacheNames = TRIPS)` 추가
- `MissionFacade` 등록/수정/삭제 메서드에 `@CacheEvict(cacheNames = TRIP)`, `@CacheEvict(cacheNames = TRIPS)` 추가
- 여행 상세 조회 및 여행 목록 조회 캐시가 **하위 리소스 변경과 함께 동기화되도록 개선**

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #85 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-