### PR TITLE
refactor: 스탬프 순서 저장 방식 리팩토링 (#88)

### DIFF
--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
@@ -24,30 +24,49 @@ public class StampCommandService {
     private final StampQueryRepository stampQueryRepository;
 
     public Stamp createStamp(Trip trip, CreateStampRequest request) {
-        Stamp newStamp =
-                StampFactory.create(trip, request.name(), request.order(), request.endDate());
+        int nextOrder = 0;
+        if (trip.getCategory() == TripCategory.COURSE) {
+            nextOrder = computeNextStampOrder(trip.getId());
+        }
 
-        List<Stamp> existingStamps =
-                stampRepository.findAllByTripIdAndDeletedAtIsNull(trip.getId());
-        List<Stamp> combinedStamps = new ArrayList<>(existingStamps);
-        combinedStamps.add(newStamp);
+        Stamp stamp = StampFactory.create(trip, request.name(), nextOrder, request.endDate());
+        StampPolicy.validateEndDate(trip.getEndDate(), stamp.getEndDate());
 
-        StampPolicy.validateStampOrders(trip.getCategory(), combinedStamps);
-        StampPolicy.validateEndDate(trip.getEndDate(), newStamp.getEndDate());
-
-        return stampRepository.save(newStamp);
+        return stampRepository.save(stamp);
     }
 
     public void createStamps(Trip trip, List<CreateStampRequest> requests) {
-        List<Stamp> stamps =
-                requests.stream()
-                        .map(
-                                stamp ->
-                                        StampFactory.create(
-                                                trip, stamp.name(), stamp.order(), stamp.endDate()))
-                        .toList();
+        if (requests == null || requests.isEmpty()) return;
 
-        StampPolicy.validateStampOrders(trip.getCategory(), stamps);
+        final List<Stamp> stamps =
+                switch (trip.getCategory()) {
+                        // 탐험형 여행일 경우
+                        // order 0 으로 전부 고정
+                    case EXPLORE -> requests.stream()
+                            .map(
+                                    stamp ->
+                                            StampFactory.create(
+                                                    trip, stamp.name(), 0, stamp.endDate()))
+                            .toList();
+
+                        // 코스형 여행일 경우
+                        // nextOrder 부터 1씩 증가하며 order 저장
+                    case COURSE -> {
+                        int nextOrder = computeNextStampOrder(trip.getId());
+
+                        List<Stamp> stampList = new ArrayList<>();
+                        for (CreateStampRequest request : requests) {
+                            Stamp stamp =
+                                    StampFactory.create(
+                                            trip, request.name(), nextOrder++, request.endDate());
+                            stampList.add(stamp);
+                        }
+
+                        yield stampList;
+                    }
+                };
+
+        stamps.forEach(stamp -> StampPolicy.validateEndDate(trip.getEndDate(), stamp.getEndDate()));
 
         stampRepository.saveAll(stamps);
     }
@@ -150,5 +169,10 @@ public class StampCommandService {
 
     public void increaseCompletedMissions(Stamp stamp, int count) {
         stamp.increaseCompletedMissions(count);
+    }
+
+    private int computeNextStampOrder(Long tripId) {
+        Integer lastOrder = stampQueryRepository.findMaxStampOrderByTripId(tripId);
+        return lastOrder == null ? 1 : lastOrder + 1;
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/domain/policy/StampPolicy.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/policy/StampPolicy.java
@@ -5,9 +5,7 @@ import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -21,30 +19,6 @@ public class StampPolicy {
     public static void validateNotDeleted(Stamp stamp) {
         if (stamp.getDeletedAt() != null)
             throw new CustomException(StampErrorCode.STAMP_ALREADY_DELETED);
-    }
-
-    public static void validateStampOrders(TripCategory tripCategory, List<Stamp> stamps) {
-        int maxOrder = stamps.size();
-        Set<Integer> orderSet = new HashSet<>();
-
-        for (Stamp stamp : stamps) {
-            int order = stamp.getStampOrder();
-
-            // 탐험형 여행이면서 순서가 존재할 경우
-            if (tripCategory == TripCategory.EXPLORE && order > 0)
-                throw new CustomException(StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP);
-
-            if (tripCategory == TripCategory.COURSE) {
-                // 코스형 여행이면서 순서가 1보다 작거나 총 개수보다 큰 경우
-                if (order < 1 || order > maxOrder)
-                    throw new CustomException(
-                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP);
-
-                // 코스형 여행이면서 중복된 순서일 경우
-                if (!orderSet.add(order))
-                    throw new CustomException(StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP);
-            }
-        }
     }
 
     public static void validateUpdateStampOrders(

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
@@ -14,4 +14,6 @@ public interface StampQueryRepository {
     long deleteAllByDeletedAtIsNotNull();
 
     long deleteAllByDeletedTripOwner();
+
+    Integer findMaxStampOrderByTripId(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
@@ -75,4 +75,13 @@ public class StampQueryRepositoryAdapter implements StampQueryRepository {
                                         .where(trip.deletedAt.isNotNull())))
                 .execute();
     }
+
+    @Override
+    public Integer findMaxStampOrderByTripId(Long tripId) {
+        return queryFactory
+                .select(stamp.stampOrder.max().coalesce(0))
+                .from(stamp)
+                .where(stamp.trip.id.eq(tripId), stamp.deletedAt.isNull())
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/CreateStampRequest.java
+++ b/src/main/java/com/ject/studytrip/stamp/presentation/dto/request/CreateStampRequest.java
@@ -2,13 +2,10 @@ package com.ject.studytrip.stamp.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.FutureOrPresent;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import java.time.LocalDate;
 
 public record CreateStampRequest(
         @Schema(description = "스탬프 이름") @NotEmpty(message = "스탬프 이름은 필수 요청 값입니다.") String name,
-        @Schema(description = "스탬프 순서") @Min(value = 0, message = "스탬프 순서는 최소 0 이상이여야 합니다.")
-                int order,
         @Schema(description = "스탬프 종료일") @FutureOrPresent(message = "스탬프 종료일은 현재 날짜보다 과거일 수 없습니다.")
                 LocalDate endDate) {}

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
@@ -64,46 +64,6 @@ class StampCommandServiceTest extends BaseUnitTest {
         private final CreateStampRequestFixture fixture = new CreateStampRequestFixture();
 
         @Test
-        @DisplayName("탐험형 여행에 순서가 지정된 스탬프를 등록하면 예외가 발생한다")
-        void shouldThrowExceptionWhenOrderSpecifiedForExploreTrip() {
-            // given
-            CreateStampRequest request = fixture.withStampOrder(1).build();
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamp(exploreTrip, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP.getMessage());
-        }
-
-        @Test
-        @DisplayName("코스형 여행에 순서가 유효 범위를 벗어난 경우 예외가 발생한다")
-        void shouldThrowExceptionWhenOrderOutOfRange() {
-            // given
-            CreateStampRequest request = fixture.withStampOrder(1000).build();
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamp(courseTrip, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP.getMessage());
-        }
-
-        @Test
-        @DisplayName("코스형 여행에 중복된 순서의 스탬프를 등록하면 예외가 발생한다")
-        void shouldThrowExceptionWhenDuplicateOrderForCourseTrip() {
-            // given
-            CreateStampRequest request = fixture.withStampOrder(1).build();
-            given(stampRepository.findAllByTripIdAndDeletedAtIsNull(courseTrip.getId()))
-                    .willReturn(List.of(courseStamp1));
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamp(courseTrip, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP.getMessage());
-        }
-
-        @Test
         @DisplayName("스탬프 종료일이 과거 날짜라면 예외가 발생한다")
         void shouldThrowExceptionWhenEndDateIsInPast() {
             // given
@@ -130,11 +90,47 @@ class StampCommandServiceTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("유효한 요청으로 스탬프를 생성하면 스탬프가 저장되고 반환된다")
+        @DisplayName("탐험형 여행에서는 order가 항상 0으로 저장된다")
+        void shouldCreateExploreStampWithOrderZero() {
+            // given
+            CreateStampRequest request = fixture.build();
+            // exploreTrip은 order 고정(0), save 응답 스텁
+            Stamp saved = Stamp.of(exploreTrip, request.name(), 0, request.endDate());
+            given(stampRepository.save(any())).willReturn(saved);
+
+            // when
+            Stamp stamp = stampCommandService.createStamp(exploreTrip, request);
+
+            // then
+            assertThat(stamp.getStampOrder()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("코스형 여행에서는 마지막 order 다음 값으로 저장된다")
+        void shouldCreateCourseStampWithNextSequentialOrder() {
+            // given
+            CreateStampRequest request = fixture.build();
+
+            // 마지막 스탬프 순서가 2라고 가정, 신규는 3으로 저장
+            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId())).willReturn(2);
+            Stamp saved = Stamp.of(courseTrip, request.name(), 3, request.endDate());
+            given(stampRepository.save(any())).willReturn(saved);
+
+            // when
+            Stamp stamp = stampCommandService.createStamp(courseTrip, request);
+
+            // then
+            assertThat(stamp.getStampOrder()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 스탬프를 생성하면 저장되고 반환된다")
         void shouldCreateValidStamp() {
             // given
             CreateStampRequest request = fixture.build();
-            Stamp saved = Stamp.of(courseTrip, request.name(), request.order(), request.endDate());
+            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId()))
+                    .willReturn(null);
+            Stamp saved = Stamp.of(courseTrip, request.name(), 1, request.endDate());
             given(stampRepository.save(any())).willReturn(saved);
 
             // when
@@ -142,7 +138,7 @@ class StampCommandServiceTest extends BaseUnitTest {
 
             // then
             assertThat(stamp.getName()).isEqualTo(saved.getName());
-            assertThat(stamp.getStampOrder()).isEqualTo(saved.getStampOrder());
+            assertThat(stamp.getStampOrder()).isEqualTo(1);
         }
     }
 
@@ -152,65 +148,27 @@ class StampCommandServiceTest extends BaseUnitTest {
         private final CreateStampRequestFixture fixture = new CreateStampRequestFixture();
 
         @Test
-        @DisplayName("탐험형 여행에서 순서가 1 이상이면 예외가 발생한다")
-        void shouldThrowExceptionWhenOrderExistsInExploreTrip() {
+        @DisplayName("탐험형 여행에서는 전달한 모든 스탬프의 order가 0으로 저장된다")
+        void shouldCreateExploreStampsWithOrderZero() {
             // given
-            List<CreateStampRequest> requests = List.of(fixture.withStampOrder(1).build());
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamps(exploreTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP.getMessage());
-        }
-
-        @Test
-        @DisplayName("코스형 여행에서 순서가 1 미만 또는 총 개수 초과라면 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderIsOutOfRangeForCourseTrip() {
-            // given
-            List<CreateStampRequest> requests = List.of(fixture.withStampOrder(2).build());
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP.getMessage());
-        }
-
-        @Test
-        @DisplayName("코스형 여행에서 순서가 중복되면 예외가 발생한다")
-        void shouldThrowExceptionWhenDuplicateOrderInCourseTrip() {
-            // given
-            List<CreateStampRequest> requests =
-                    List.of(fixture.withStampOrder(1).build(), fixture.withStampOrder(1).build());
-
-            // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamps(courseTrip, requests))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP.getMessage());
-        }
-
-        @Test
-        @DisplayName("코스형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
-        void shouldCreateStampsForCourseTrip() {
-            // given
-            List<CreateStampRequest> requests = List.of(fixture.build());
+            List<CreateStampRequest> requests = List.of(fixture.build(), fixture.build());
 
             // when
-            stampCommandService.createStamps(courseTrip, requests);
+            stampCommandService.createStamps(exploreTrip, requests);
 
             // then
             verify(stampRepository).saveAll(anyList());
         }
 
         @Test
-        @DisplayName("탐험형 여행의 유효한 스탬프 리스트를 넘기면 저장된다")
-        void shouldCreateStampsForExploreTrip() {
+        @DisplayName("코스형 여행에서는 마지막 order 다음 값부터 순차적으로 저장된다")
+        void shouldCreateCourseStampsSequentiallyFromNextOrder() {
             // given
-            List<CreateStampRequest> requests = List.of(fixture.withStampOrder(0).build());
+            List<CreateStampRequest> requests = List.of(fixture.build(), fixture.build());
+            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId())).willReturn(5);
 
             // when
-            stampCommandService.createStamps(exploreTrip, requests);
+            stampCommandService.createStamps(courseTrip, requests);
 
             // then
             verify(stampRepository).saveAll(anyList());
@@ -225,6 +183,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         @Test
         @DisplayName("유효한 정보로 스탬프의 이름을 수정하면 스탬프가 업데이트된다")
         void shouldUpdateStampName() {
+
             // given
             UpdateStampRequest request = fixture.buildUpdateName();
 

--- a/src/test/java/com/ject/studytrip/stamp/fixture/CreateStampRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/CreateStampRequestFixture.java
@@ -6,16 +6,10 @@ import java.time.LocalDate;
 public class CreateStampRequestFixture {
 
     private String name = "TEST STAMP";
-    private int stampOrder = 1;
-    private LocalDate endDate = LocalDate.now().plusDays(7);
+    private java.time.LocalDate endDate = java.time.LocalDate.now().plusDays(7);
 
     public CreateStampRequestFixture withName(String name) {
         this.name = name;
-        return this;
-    }
-
-    public CreateStampRequestFixture withStampOrder(int stampOrder) {
-        this.stampOrder = stampOrder;
         return this;
     }
 
@@ -30,6 +24,6 @@ public class CreateStampRequestFixture {
     }
 
     public CreateStampRequest build() {
-        return new CreateStampRequest(name, stampOrder, endDate);
+        return new CreateStampRequest(name, endDate);
     }
 }

--- a/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
@@ -3,12 +3,12 @@ package com.ject.studytrip.stamp.fixture;
 import com.ject.studytrip.stamp.domain.factory.StampFactory;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.trip.domain.model.Trip;
-import java.time.LocalDate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class StampFixture {
     private static final String STAMP_NAME = "TEST STAMP NAME";
-    private static final LocalDate DEFAULT_END_DATE = LocalDate.now().plusDays(7);
+    private static final java.time.LocalDate DEFAULT_END_DATE =
+            java.time.LocalDate.now().plusDays(7);
 
     public static Stamp createStamp(Trip trip, int order) {
         return StampFactory.create(trip, STAMP_NAME, order, DEFAULT_END_DATE);

--- a/src/test/java/com/ject/studytrip/stamp/fixture/UpdateStampRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/UpdateStampRequestFixture.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 
 public class UpdateStampRequestFixture {
     private String name = "TEST STAMP";
-    private LocalDate endDate = LocalDate.now().plusDays(7);
+    private java.time.LocalDate endDate = java.time.LocalDate.now().plusDays(7);
 
     public UpdateStampRequestFixture withName(String name) {
         this.name = name;

--- a/src/test/java/com/ject/studytrip/stamp/presentation/controller/StampControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/presentation/controller/StampControllerIntegrationTest.java
@@ -97,8 +97,7 @@ public class StampControllerIntegrationTest extends BaseIntegrationTest {
         @DisplayName("유효한 요청으로 특정 여행의 스탬프를 생성하고, 여행 총 스탬프 수가 증가한다")
         void shouldCreateStamp() throws Exception {
             // given
-            CreateStampRequest request =
-                    createStampRequestFixture.withStampOrder(NEXT_STAMP_ORDER).build();
+            CreateStampRequest request = createStampRequestFixture.build();
 
             // when
             ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
@@ -225,48 +224,6 @@ public class StampControllerIntegrationTest extends BaseIntegrationTest {
                     .andExpect(
                             jsonPath("$.status")
                                     .value(TripErrorCode.TRIP_ALREADY_DELETED.getStatus().value()));
-        }
-
-        @Test
-        @DisplayName("탐험형 여행에 순서가 존재하는 스탬프를 추가하면 400 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderExistsInExplorationTrip() throws Exception {
-            // given
-            CreateStampRequest request = createStampRequestFixture.build();
-
-            // when
-            ResultActions resultActions = getResultActions(token, exploreTrip.getId(), request);
-
-            // when & then
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(
-                            jsonPath("$.status")
-                                    .value(
-                                            StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP
-                                                    .getStatus()
-                                                    .value()));
-        }
-
-        @Test
-        @DisplayName("코스형 여행에 유효하지 않은 순서(중복, 범위 이탈)가 존재하는 스탬프를 추가하면 400 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderOutOfRangeInCourseTrip() throws Exception {
-            // given
-            CreateStampRequest request = createStampRequestFixture.build();
-
-            // when
-            ResultActions resultActions = getResultActions(token, courseTrip.getId(), request);
-
-            // when & then
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(
-                            jsonPath("$.status")
-                                    .value(
-                                            StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP
-                                                    .getStatus()
-                                                    .value()));
         }
     }
 

--- a/src/test/java/com/ject/studytrip/trip/fixture/CreateTripRequestFixture.java
+++ b/src/test/java/com/ject/studytrip/trip/fixture/CreateTripRequestFixture.java
@@ -13,10 +13,7 @@ public class CreateTripRequestFixture {
     private String memo = "TEST 여행입니다.";
     private String category = TripCategory.COURSE.name();
     private LocalDate endDate = LocalDate.now().plusDays(10);
-    private List<CreateStampRequest> stamps =
-            List.of(
-                    new CreateStampRequestFixture().build(),
-                    new CreateStampRequestFixture().withStampOrder(2).build());
+    private List<CreateStampRequest> stamps = List.of(new CreateStampRequestFixture().build());
 
     public CreateTripRequestFixture withName(String name) {
         this.name = name;

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/TripControllerIntegrationTest.java
@@ -16,9 +16,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.helper.MemberTestHelper;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.model.Stamp;
-import com.ject.studytrip.stamp.fixture.CreateStampRequestFixture;
 import com.ject.studytrip.stamp.helper.StampTestHelper;
-import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
 import com.ject.studytrip.trip.domain.error.TripErrorCode;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
@@ -208,71 +206,6 @@ public class TripControllerIntegrationTest extends BaseIntegrationTest {
             // when & then
             resultActions.andExpect(
                     status().is(TripErrorCode.TRIP_STAMP_REQUIRED.getStatus().value()));
-        }
-
-        @Test
-        @DisplayName("탐험형 여행을 선택하고 스탬프 순서가 존재할 경우 400 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderExistsInExplorationTrip() throws Exception {
-            // given
-            List<CreateStampRequest> stampRequests =
-                    List.of(new CreateStampRequestFixture().build());
-            CreateTripRequest request =
-                    new CreateTripRequestFixture()
-                            .withCategory(TRIP_CATEGORY_EXPLORE)
-                            .withStamps(stampRequests)
-                            .build();
-
-            // when
-            ResultActions resultActions = getResultActions(token, request);
-
-            // when & then
-            resultActions.andExpect(
-                    status().is(
-                                    StampErrorCode.INVALID_STAMP_ORDER_FOR_EXPLORATION_TRIP
-                                            .getStatus()
-                                            .value()));
-        }
-
-        @Test
-        @DisplayName("코스형 여행을 선택하고 스탬프 순서가 1 미만 또는 최대 총 개수를 초과하면 400 예외가 발생한다")
-        void shouldThrowExceptionWhenStampOrderOutOfRangeInCourseTrip() throws Exception {
-            // given
-            List<CreateStampRequest> stampRequests =
-                    List.of(new CreateStampRequestFixture().withStampOrder(2).build());
-            CreateTripRequest request =
-                    new CreateTripRequestFixture().withStamps(stampRequests).build();
-
-            // when
-            ResultActions resultActions = getResultActions(token, request);
-
-            // when & then
-            resultActions.andExpect(
-                    status().is(
-                                    StampErrorCode.INVALID_STAMP_ORDER_RANGE_FOR_COURSE_TRIP
-                                            .getStatus()
-                                            .value()));
-        }
-
-        @Test
-        @DisplayName("코스형 여행을 선택하고 스탬프 순서에 중복이 존재할 경우 400 예외가 발생한다")
-        void shouldThrowExceptionWhenDuplicateStampOrderInCourseTrip() throws Exception {
-            // given
-            List<CreateStampRequest> stampRequests =
-                    List.of(
-                            new CreateStampRequestFixture().withStampOrder(1).build(),
-                            new CreateStampRequestFixture().withStampOrder(1).build());
-            CreateTripRequest request =
-                    new CreateTripRequestFixture().withStamps(stampRequests).build();
-
-            // when
-            ResultActions resultActions = getResultActions(token, request);
-
-            // when & then
-            resultActions.andExpect(
-                    status().is(
-                                    StampErrorCode.DUPLICATE_STAMP_ORDER_FOR_COURSE_TRIP
-                                            .getStatus()
-                                            .value()));
         }
     }
 


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 스탬프 순서 지정 방식 변경
- 스탬프를 생성할 때 순서를 지정하는 방법을 
**클라이언트에서 order 계산 후 요청, 서버에서 order 검증** -> **서버에서 특정 여행의 마지막 스탬프 order 값을 추출해 지정**하는 방법으로 변경했습니다.

**[ 리팩토링 전 ]**
```
1. 스탬프 생성 요청 시 클라이언트에서 order 요청
2. 여행의 카테고리(코스/탐험)에 따라 order 검증
3. 검증에 성공하면 order 반영
```

**[ 리팩토링 후 ]**
```
1. 스탬프 생성 시 name, end_date 필드만 요청
2. 여행의 카테고리(코스/탐험) 판단
3. 코스형 여행일 경우, 해당 여행에 속한 스탬프 중 마지막 order를 추출해 +1 한 값으로 stamp_order 지정하고 스탬프 생성
5. 탐험형 여행일 경우, stamp_order를 0으로 지정하고 스탬프 생성
```

- 스탬프 생성 `CreateStampRequest DTO`에서 order 필드를 제거했습니다.
- 특정 여행의 스탬프 중 마지막 순서를 추출하는 `findMaxStampOrderByTripId()` 쿼리 메서드를 추가했습니다.
- 새로운 스탬프를 생성할 때 먼저 여행의 카테고리를 비교하고, `stamp_order` 필드에 코스형 여행일 경우에는 `findMaxStampOrderByTripId() + 1` 값을, 탐험형 여행일 경우에는 `0`을 지정해 스탬프를 생성하도록 구현했습니다.
- 기존 클라이언트로부터 요청받은 `order` 값을 검증하는 `StampPolicy.validateStampOrder` 메서드를 제거했습니다.
서버에서 검증된 순서를 지정하고 직접 순서를 계산/추출하기때문에 검증까지 수행하지 않도록 구성했습니다.
- 단일 스탬프 생성(`StampCommandService.createStamp`) 로직과 다중 스탬프 생성(`StampCommandService.createStamps`) 모두 변경사항을 반영했습니다.

<br/>

### ✅ 관련 테스트 코드 수정
- `StampControllerIntegrationTest`에서 단일 스탬프 생성 테스트 코드의 스탬프 순서 관련 예외 반환 테스트를 제거했습니다.
- `StampCommandServiceTest`에서 단일 스탬프 생성, 다중 스탬프 생성 테스트 코드를 로직 변경에 맞게 수정했습니다.
- `TripControllerIntegrationTest`에서 여행 생성 테스트 코드의 스탬프 순서 관련 예외 반환 테스트를 제거했습니다.
- Stamp Fixture 클래스에서 order 관련 변경사항을 적용했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #88 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-