### PR TITLE
fix: 여행 리포트 API 응답 필드 매핑 오류 수정(#90)

### DIFF
--- a/src/main/java/com/ject/studytrip/trip/domain/model/TripReport.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/model/TripReport.java
@@ -47,10 +47,10 @@ public class TripReport extends BaseTimeEntity {
 
     public static TripReport of(
             Member member,
-            String startDate,
-            String endDate,
             String title,
             String content,
+            String startDate,
+            String endDate,
             long completedMissionCount,
             long totalFocusHours,
             long studyDays,


### PR DESCRIPTION
* refactor: TripReport.of()에서 매개변수 순서 조정

## 📌 작업 내용 및 특이사항

### ✅ TripReport.of() 매개변수 순서 조정
- 여행 리포트 목록 조회(`/api/trip-reports`) 및 상세 조회(`/api/trip-reports/{tripReportId}`) API에서 **응답 필드 매핑이 잘못**되어 데이터가 뒤바뀌어 표시
- `startDate(여행 생성일)`와 `title(여행 리포트 제목)`가 뒤바뀌어 표시되고, `endDate(여행 종료일)`와 `content(여행 리포트 내용)`이 뒤바뀌어 표시
- `TripReport.of()`에서 매개변수 순서가 잘못되어 발생한 오류를 확인하고, 매개변수 순서를 조정하여 오류 해결

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #90 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-