### PR TITLE
feat: Spring Batch 기반 TripReport 연관 엔티티 삭제 및 하드 딜리트 기능 추가(#92)

### DIFF
--- a/src/main/java/com/ject/studytrip/cleanup/application/facade/HardDeleteFacade.java
+++ b/src/main/java/com/ject/studytrip/cleanup/application/facade/HardDeleteFacade.java
@@ -10,6 +10,8 @@ import com.ject.studytrip.studylog.application.service.StudyLogCommandService;
 import com.ject.studytrip.studylog.application.service.StudyLogDailyMissionCommandService;
 import com.ject.studytrip.trip.application.service.DailyGoalCommandService;
 import com.ject.studytrip.trip.application.service.TripCommandService;
+import com.ject.studytrip.trip.application.service.TripReportCommandService;
+import com.ject.studytrip.trip.application.service.TripReportStudyLogCommandService;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,8 @@ public class HardDeleteFacade {
     private final StudyLogDailyMissionCommandService studyLogDailyMissionCommandService;
     private final DailyGoalCommandService dailyGoalCommandService;
     private final PomodoroCommandService pomodoroCommandService;
+    private final TripReportCommandService tripReportCommandService;
+    private final TripReportStudyLogCommandService tripReportStudyLogCommandService;
 
     private final HardDeleteExecutor executor;
 
@@ -46,6 +50,10 @@ public class HardDeleteFacade {
             "dailyMissionsOwnedByDeletedMission";
     private static final String DAILY_MISSIONS_OWNED_BY_DELETED_DAILY_GOAL =
             "dailyMissionsOwnedByDeletedDailyGoal";
+    private static final String TRIP_REPORT_STUDY_LOGS_OWNED_BY_DELETED_MEMBER =
+            "tripReportStudyLogsOwnedByDeletedMember";
+    private static final String TRIP_REPORTS_OWNED_BY_DELETED_MEMBER =
+            "tripReportsOwnedByDeletedMember";
 
     private static final String POMODOROS = "pomodoros";
     private static final String STUDY_LOG_DAILY_MISSIONS = "studyLogDailyMissions";
@@ -68,6 +76,8 @@ public class HardDeleteFacade {
         deletePomodoros(phases); // 뽀모도로 삭제
         deleteStudyLogDailyMissions(phases); // StudyLogDailyMission 삭제
         deleteDailyMissions(phases); // 데일리 미션 삭제
+        deleteTripReportStudyLogs(phases); // TripReportStudyLog 삭제
+        deleteTripReports(phases); // 여행 리포트 삭제
         deleteStudyLogs(phases); // 학습 로그 삭제
         deleteDailyGoals(phases); // 데일리 목표 삭제
         deleteMissions(phases); // 미션 삭제
@@ -120,6 +130,23 @@ public class HardDeleteFacade {
         phases.put(
                 DAILY_MISSIONS,
                 executor.run(DAILY_MISSIONS, dailyMissionCommandService::hardDeleteDailyMissions));
+    }
+
+    private void deleteTripReportStudyLogs(Map<String, Long> phases) {
+        phases.put(
+                TRIP_REPORT_STUDY_LOGS_OWNED_BY_DELETED_MEMBER,
+                executor.run(
+                        TRIP_REPORT_STUDY_LOGS_OWNED_BY_DELETED_MEMBER,
+                        tripReportStudyLogCommandService
+                                ::hardDeleteTripReportStudyLogsOwnedByDeletedMember));
+    }
+
+    private void deleteTripReports(Map<String, Long> phases) {
+        phases.put(
+                TRIP_REPORTS_OWNED_BY_DELETED_MEMBER,
+                executor.run(
+                        TRIP_REPORTS_OWNED_BY_DELETED_MEMBER,
+                        tripReportCommandService::hardDeleteTripReportsOwnedByDeletedMember));
     }
 
     private void deleteStudyLogs(Map<String, Long> phases) {

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
@@ -3,6 +3,7 @@ package com.ject.studytrip.trip.application.service;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.factory.TripReportFactory;
 import com.ject.studytrip.trip.domain.model.TripReport;
+import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import com.ject.studytrip.trip.presentation.dto.request.CreateTripReportRequest;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripReportCommandService {
     private final TripReportRepository tripReportRepository;
+    private final TripReportQueryRepository tripReportQueryRepository;
 
     public TripReport createTripReport(Member member, CreateTripReportRequest request) {
         TripReport tripReport =
@@ -31,5 +33,9 @@ public class TripReportCommandService {
 
     public void updateImageUrl(TripReport tripReport, String imageUrl) {
         tripReport.updateImageUrl(imageUrl);
+    }
+
+    public long hardDeleteTripReportsOwnedByDeletedMember() {
+        return tripReportQueryRepository.deleteAllByDeletedMemberOwner();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
@@ -4,6 +4,7 @@ import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.trip.domain.factory.TripReportStudyLogFactory;
 import com.ject.studytrip.trip.domain.model.TripReport;
 import com.ject.studytrip.trip.domain.model.TripReportStudyLog;
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportStudyLogRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripReportStudyLogCommandService {
     private final TripReportStudyLogRepository tripReportStudyLogRepository;
+    private final TripReportStudyLogQueryRepository tripReportStudyLogQueryRepository;
 
     public void createTripReportStudyLogs(TripReport tripReport, List<StudyLog> studyLogs) {
         List<TripReportStudyLog> tripReportStudyLogs =
@@ -21,5 +23,9 @@ public class TripReportStudyLogCommandService {
                         .toList();
 
         tripReportStudyLogRepository.saveAll(tripReportStudyLogs);
+    }
+
+    public long hardDeleteTripReportStudyLogsOwnedByDeletedMember() {
+        return tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
@@ -1,0 +1,5 @@
+package com.ject.studytrip.trip.domain.repository;
+
+public interface TripReportQueryRepository {
+    long deleteAllByDeletedMemberOwner();
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogQueryRepository.java
@@ -1,0 +1,5 @@
+package com.ject.studytrip.trip.domain.repository;
+
+public interface TripReportStudyLogQueryRepository {
+    long deleteAllByDeletedMemberOwner();
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.ject.studytrip.trip.infra.querydsl;
+
+import com.ject.studytrip.member.domain.model.QMember;
+import com.ject.studytrip.trip.domain.model.QTripReport;
+import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TripReportQueryRepositoryAdapter implements TripReportQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QTripReport tripReport = QTripReport.tripReport;
+    private final QMember member = QMember.member;
+
+    @Override
+    public long deleteAllByDeletedMemberOwner() {
+        return queryFactory
+                .delete(tripReport)
+                .where(
+                        tripReport.member.id.in(
+                                JPAExpressions.select(member.id)
+                                        .from(member)
+                                        .where(member.deletedAt.isNotNull())))
+                .execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogQueryRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.ject.studytrip.trip.infra.querydsl;
+
+import com.ject.studytrip.member.domain.model.QMember;
+import com.ject.studytrip.studylog.domain.model.QStudyLog;
+import com.ject.studytrip.trip.domain.model.QTripReport;
+import com.ject.studytrip.trip.domain.model.QTripReportStudyLog;
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TripReportStudyLogQueryRepositoryAdapter implements TripReportStudyLogQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QTripReportStudyLog tripReportStudyLog = QTripReportStudyLog.tripReportStudyLog;
+    private final QTripReport tripReport = QTripReport.tripReport;
+    private final QStudyLog studyLog = QStudyLog.studyLog;
+    private final QMember member = QMember.member;
+
+    @Override
+    public long deleteAllByDeletedMemberOwner() {
+        return queryFactory
+                .delete(tripReportStudyLog)
+                .where(
+                        tripReportStudyLog
+                                .tripReport
+                                .id
+                                .in(
+                                        JPAExpressions.select(tripReport.id)
+                                                .from(tripReport)
+                                                .join(tripReport.member, member)
+                                                .where(member.deletedAt.isNotNull()))
+                                .or(
+                                        tripReportStudyLog.studyLog.id.in(
+                                                JPAExpressions.select(studyLog.id)
+                                                        .from(studyLog)
+                                                        .join(studyLog.member, member)
+                                                        .where(member.deletedAt.isNotNull()))))
+                .execute();
+    }
+}

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
@@ -8,6 +8,7 @@ import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.model.TripReport;
+import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import com.ject.studytrip.trip.fixture.CreateTripReportRequestFixture;
 import com.ject.studytrip.trip.fixture.TripReportFixture;
@@ -23,6 +24,7 @@ import org.mockito.Mock;
 class TripReportCommandServiceTest extends BaseUnitTest {
     @InjectMocks private TripReportCommandService tripReportCommandService;
     @Mock private TripReportRepository tripReportRepository;
+    @Mock private TripReportQueryRepository tripReportQueryRepository;
 
     private Member member;
     private TripReport tripReport;
@@ -70,6 +72,37 @@ class TripReportCommandServiceTest extends BaseUnitTest {
             // then
             assertThat(tripReport.getImageUrl()).isEqualTo(NEW_IMAGE_URL);
             assertThat(tripReport.getImageUrl()).isNotEqualTo(oldImageUrl);
+        }
+    }
+
+    @Nested
+    @DisplayName("hardDeleteTripReportsOwnedByDeletedMember 메서드는")
+    class HardDeleteTripReportsOwnedByDeletedMember {
+
+        @Test
+        @DisplayName("삭제된 멤버가 소유한 여행 리포트가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenTripReportsOwnedByDeletedMemberDoNotExist() {
+            // given
+            given(tripReportQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+
+            // when
+            long result = tripReportCommandService.hardDeleteTripReportsOwnedByDeletedMember();
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("삭제된 멤버가 소유한 여행 리포트가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenTripReportsOwnedByDeletedMemberExist() {
+            // given
+            given(tripReportQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+
+            // when
+            long result = tripReportCommandService.hardDeleteTripReportsOwnedByDeletedMember();
+
+            // then
+            assertThat(result).isEqualTo(5L);
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
@@ -1,6 +1,8 @@
 package com.ject.studytrip.trip.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,6 +13,7 @@ import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.fixture.StudyLogFixture;
 import com.ject.studytrip.trip.domain.model.*;
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportStudyLogRepository;
 import com.ject.studytrip.trip.fixture.DailyGoalFixture;
 import com.ject.studytrip.trip.fixture.TripFixture;
@@ -27,6 +30,7 @@ import org.mockito.Mock;
 class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
     @InjectMocks private TripReportStudyLogCommandService tripReportStudyLogCommandService;
     @Mock private TripReportStudyLogRepository tripReportStudyLogRepository;
+    @Mock private TripReportStudyLogQueryRepository tripReportStudyLogQueryRepository;
 
     private TripReport tripReport;
     private List<StudyLog> studyLogs;
@@ -57,6 +61,56 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
 
             // then
             verify(tripReportStudyLogRepository, times(1)).saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("hardDeleteTripReportStudyLogsOwnedByDeletedMember 메서드는")
+    class HardDeleteTripReportStudyLogsOwnedByDeletedMember {
+
+        @Test
+        @DisplayName("삭제된 멤버가 소유한 여행 리포트가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenTripReportsOwnedByDeletedMemberDoNotExist() {
+            // given
+            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+
+            // when
+            long result =
+                    tripReportStudyLogCommandService
+                            .hardDeleteTripReportStudyLogsOwnedByDeletedMember();
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("삭제된 멤버가 소유한 학습 로그가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenStudyLogsOwnedByDeletedMemberDoNotExist() {
+            // given
+            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+
+            // when
+            long result =
+                    tripReportStudyLogCommandService
+                            .hardDeleteTripReportStudyLogsOwnedByDeletedMember();
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("삭제된 멤버가 소유한 여행 리포트 또는 학습 로그가 있으면 삭제된 TripReportStudyLog 개수를 반환한다.")
+        void shouldReturnCountWhenTripReportsOrStudyLogsOwnedByDeletedMemberExist() {
+            // given
+            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+
+            // when
+            long result =
+                    tripReportStudyLogCommandService
+                            .hardDeleteTripReportStudyLogsOwnedByDeletedMember();
+
+            // then
+            assertThat(result).isEqualTo(5L);
         }
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ TripReport, TripReportStudyLog 연관 엔티티 삭제 및 하드 딜리트 기능 추가
- `TripReportQueryRepository.deleteAllByDeletedMemberOwner()`를 통해 **삭제된 멤버가 소유한 여행 리포트 삭제**
- `TripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()`를 통해 삭제된 멤버가 소유한 여행 리포트 또는 학습 로그가 존재하면, **연관된 TripReportStudy 삭제**
- `TripReportCommandService`, `TripReportStudyLogCommandService`에 **하드 딜리트 비즈니스 로직** 추가

### ✅ HardDeleteFacade에 TripReport, TripReportStudyLog에 하드 딜리트 비즈니스 로직 추가
- `BatchJobScheduler`를 통해 **매일 04시**에 하드 딜리트 삭제 처리 진행
- `HardDeleteExecutor`를 통해 **배치 처리 로그** 기록 작성

### ✅ 테스트
- `TripReportCommandServiceTest`에 `HardDeleteTripReportsOwnedByDeletedMember` 단위 테스트 추가
- `TripReportStudyLogCommandServiceTest`에 `HardDeleteTripReportStudyLogsOwnedByDeletedMember` 단위 테스트 추가

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #92 

<br/>

## 🔍 참고사항(선택)

- StudyLog와 TripReport에 `updateDeletedAt()`이 없기 때문에, 삭제된 멤버를 기준으로 `TripReportStudyLog`를 삭제하는 비즈니스 로직을 구현했습니다.

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-