### PR TITLE
refactor: 여행 회고 응답 DTO에 StudyLogId 목록 추가(#101)

### DIFF
--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogQueryService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogQueryService.java
@@ -56,4 +56,8 @@ public class StudyLogQueryService {
         return studyLogQueryRepository.findSliceByTripReportIdOrderByCreatedAtDesc(
                 tripReportId, PageRequest.of(page, size));
     }
+
+    public List<Long> getStudyLogIdsByTripId(Long tripId) {
+        return studyLogQueryRepository.findAllIdsByTripIdOrderByCreatedDesc(tripId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
@@ -1,6 +1,7 @@
 package com.ject.studytrip.studylog.domain.repository;
 
 import com.ject.studytrip.studylog.domain.model.StudyLog;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -19,4 +20,6 @@ public interface StudyLogQueryRepository {
 
     Slice<StudyLog> findSliceByTripReportIdOrderByCreatedAtDesc(
             Long tripReportId, Pageable pageable);
+
+    List<Long> findAllIdsByTripIdOrderByCreatedDesc(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
@@ -126,6 +126,20 @@ public class StudyLogQueryRepositoryAdapter implements StudyLogQueryRepository {
         return new SliceImpl<>(result, pageable, hasNext);
     }
 
+    @Override
+    public List<Long> findAllIdsByTripIdOrderByCreatedDesc(Long tripId) {
+        return queryFactory
+                .select(studyLog.id)
+                .from(studyLog)
+                .join(studyLog.dailyGoal, dailyGoal)
+                .where(
+                        dailyGoal.trip.id.eq(tripId),
+                        studyLog.deletedAt.isNull(),
+                        dailyGoal.deletedAt.isNull())
+                .orderBy(studyLog.createdAt.desc())
+                .fetch();
+    }
+
     private OrderSpecifier<?>[] orderSpecifiers(String order) {
         return (order.equalsIgnoreCase("OLDEST"))
                 ? new OrderSpecifier<?>[] {studyLog.createdAt.asc(), studyLog.id.asc()}

--- a/src/main/java/com/ject/studytrip/trip/application/dto/TripRetrospectSummary.java
+++ b/src/main/java/com/ject/studytrip/trip/application/dto/TripRetrospectSummary.java
@@ -1,12 +1,15 @@
 package com.ject.studytrip.trip.application.dto;
 
+import java.util.List;
+
 public record TripRetrospectSummary(
         long studyLogCount, // 학습 로그 개수
         long totalFocusHours, // 총 집중 시간(시간 단위)
-        long studyDays // 학습한 일수(중복 날짜 제거)
+        long studyDays, // 학습한 일수(중복 날짜 제거)
+        List<Long> studyLogIds // 학습 로그 ID 목록
         ) {
     public static TripRetrospectSummary of(
-            long studyLogCount, long totalFocusHours, long studyDays) {
-        return new TripRetrospectSummary(studyLogCount, totalFocusHours, studyDays);
+            long studyLogCount, long totalFocusHours, long studyDays, List<Long> studyLogIds) {
+        return new TripRetrospectSummary(studyLogCount, totalFocusHours, studyDays, studyLogIds);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripReportFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripReportFacade.java
@@ -61,9 +61,10 @@ public class TripReportFacade {
                                 0,
                                 ChronoUnit.DAYS.between(trip.getStartDate(), trip.getEndDate()) + 1)
                         : 0L;
+        List<Long> studyLogIds = studyLogQueryService.getStudyLogIdsByTripId(trip.getId());
 
         TripRetrospectSummary summary =
-                TripRetrospectSummary.of(studyLogCount, totalFocusHours, studyDays);
+                TripRetrospectSummary.of(studyLogCount, totalFocusHours, studyDays, studyLogIds);
         TripInfo tripInfo = TripInfo.from(trip, 0, 100);
         StudyLogSliceInfo studyLogDetailSlice = buildStudyLogDetailsSlice(studyLogSlice);
 

--- a/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadTripRetrospectDetailResponse.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/dto/response/LoadTripRetrospectDetailResponse.java
@@ -5,6 +5,7 @@ import com.ject.studytrip.studylog.presentation.dto.response.LoadStudyLogsSliceR
 import com.ject.studytrip.trip.application.dto.TripInfo;
 import com.ject.studytrip.trip.application.dto.TripRetrospectSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public record LoadTripRetrospectDetailResponse(
         @Schema(description = "여행 이름") String name,
@@ -13,6 +14,7 @@ public record LoadTripRetrospectDetailResponse(
         @Schema(description = "총 학습 시간") long totalFocusHours,
         @Schema(description = "학습 로그 개수 (세션 성공)") long studyLogCount,
         @Schema(description = "연속 학습일") long studyDays,
+        @Schema(description = "학습 로그 ID 목록") List<Long> studyLogIds,
         @Schema(description = "학습 로그 히스토리") LoadStudyLogsSliceResponse history) {
     public static LoadTripRetrospectDetailResponse of(
             TripRetrospectSummary tripRetrospectSummary,
@@ -25,6 +27,7 @@ public record LoadTripRetrospectDetailResponse(
                 tripRetrospectSummary.totalFocusHours(),
                 tripRetrospectSummary.studyLogCount(),
                 tripRetrospectSummary.studyDays(),
+                tripRetrospectSummary.studyLogIds(),
                 LoadStudyLogsSliceResponse.of(
                         studyLogDetailSlice.studyLogDetails(), studyLogDetailSlice.hasNext()));
     }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogQueryServiceTest.java
@@ -278,4 +278,45 @@ class StudyLogQueryServiceTest extends BaseUnitTest {
             assertThat(result.getContent().get(1)).isEqualTo(studyLog2);
         }
     }
+
+    @Nested
+    @DisplayName("getStudyLogIdsByTripId 메서드는")
+    class GetStudyLogIdsByTripId {
+
+        @Test
+        @DisplayName("학습 로그가 존재하지 않으면 빈 리스트를 반환한다.")
+        void shouldReturnEmptyListWhenStudyLogDoesNotExist() {
+            // given
+            Long tripId = courseTrip.getId();
+            studyLog1.updateDeletedAt();
+            studyLog2.updateDeletedAt();
+            given(studyLogQueryRepository.findAllIdsByTripIdOrderByCreatedDesc(tripId))
+                    .willReturn(List.of());
+
+            // when
+            List<Long> result = studyLogQueryService.getStudyLogIdsByTripId(tripId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("학습 로그가 하나라도 존재하면 학습 로그 ID 목록을 반환한다.")
+        void shouldReturnStudyLogIdsWhenStudyLogExists() {
+            // given
+            Long tripId = courseTrip.getId();
+            Long studyLogId1 = studyLog1.getId();
+            Long studyLogId2 = studyLog2.getId();
+            given(studyLogQueryRepository.findAllIdsByTripIdOrderByCreatedDesc(tripId))
+                    .willReturn(List.of(studyLogId1, studyLogId2));
+
+            // when
+            List<Long> result = studyLogQueryService.getStudyLogIdsByTripId(tripId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0)).isEqualTo(studyLogId1);
+            assertThat(result.get(1)).isEqualTo(studyLogId2);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/presentation/controller/TripReportControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/trip/presentation/controller/TripReportControllerIntegrationTest.java
@@ -302,6 +302,7 @@ class TripReportControllerIntegrationTest extends BaseIntegrationTest {
                     .andExpect(jsonPath("$.data.name").isString())
                     .andExpect(jsonPath("$.data.totalFocusHours").isNumber())
                     .andExpect(jsonPath("$.data.studyLogCount").isNumber())
+                    .andExpect(jsonPath("$.data.studyLogIds").isArray())
                     .andExpect(jsonPath("$.data.studyDays").isNumber())
                     .andExpect(jsonPath("$.data.history").isNotEmpty());
         }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 여행 회고 응답 DTO 수정
* 여행 회고 응답 DTO에 `List<Long> studyLogIds`를 추가
* `여행 리포트 생성 API`에서 요청 값 생성할 때, 기존 방식은 **무한 스크롤**을 이용해 `StudyLogId 목록`을 전달하는 방식 사용
* 하지만, 여행 회고 응답 DTO에 `List<Long> studyLogIds`를 같이 전달하여, 해당 문제를 해결하고 **UX**를 향상시킴

### ✅ StudyLogId 목록 조회 메서드 추가
* `StudyLogQueryRepository`, `StudyLogQueryRepositoryAdapter`에 `findAllIdsByTripIdOrderByCreatedDesc` 메서드 추가
* `StudyLogQueryService`에 `getStudyLogIdsByTripId` 메서드 추가

### ✅ DTO 수정
* `TripRetrospectSummary`에 `List<Long> studyLogIds` 추가
* `LoadTripRetrospectDetailResponse`에 `List<Long> studyLogIds` 추가

### ✅ 테스트
* `StudyLogQueryServiceTest`에 `GetStudyLogIdsByTripId` 단위 테스트 추가
* `TripReportControllerIntegrationTest`에서 `LoadTripRetrospect` 통합 테스트 수정

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #101 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-