### PR TITLE
fix: 리프레시 쿠키 만료일 문제 수정 (#103)

### DIFF
--- a/src/main/java/com/ject/studytrip/auth/presentation/helper/AuthCookieHelper.java
+++ b/src/main/java/com/ject/studytrip/auth/presentation/helper/AuthCookieHelper.java
@@ -11,8 +11,8 @@ public final class AuthCookieHelper {
                 OAUTH_SIGNUP_KEY, value, Duration.ofMillis(OAUTH_SIGNUP_COOKIE_TTL_MILLIS));
     }
 
-    public static ResponseCookie setRefreshTokenCookie(String value, long maxAge) {
-        return setResponseCookie(AUTH_REFRESH_TOKEN, value, Duration.ofMillis(maxAge));
+    public static ResponseCookie setRefreshTokenCookie(String value, long maxAgeInSeconds) {
+        return setResponseCookie(AUTH_REFRESH_TOKEN, value, Duration.ofSeconds(maxAgeInSeconds));
     }
 
     private static ResponseCookie setResponseCookie(String name, String value, Duration maxAge) {


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 리프레시 쿠키 만료일 문제 해결
- 리프레시 토큰 저장을 저장할 경우 `Redis` `TTL`이 7일로 설정되지만 리프레시 쿠키의 경우 10분으로 설정되는 문제를 발견했습니다.
- 기존에는 쿠키의 `Max-Age`를 `Redis` `TTL`과 동일하게 `milliseconds`로 설정했지만, 쿠키의 `Max-Age`는 HTTP 표준(RFC 6265)에 따라 초 단위로 정의되고, 브라우저는 초 단위로만 쿠키를 처리한다고 합니다.
이를 반영해 `Duration.ofMillis()` 대신 `Duration.ofSeconds()`를 사용해 설정값(초 단위)을 그대로 전달하도록 수정했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #103 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-