### PR TITLE
refactor: 여행 목록 조회 리팩토링 (#105)

### DIFF
--- a/src/main/java/com/ject/studytrip/trip/application/service/TripQueryService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripQueryService.java
@@ -38,7 +38,8 @@ public class TripQueryService {
     }
 
     public Slice<Trip> getTripsSliceByMemberId(Long memberId, int page, int size) {
-        return tripQueryRepository.findSliceByMemberId(memberId, PageRequest.of(page, size));
+        return tripQueryRepository.findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull(
+                memberId, PageRequest.of(page, size));
     }
 
     public TripCount getActiveTripCountsByMemberId(Long memberId) {

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface TripQueryRepository {
-    Slice<Trip> findSliceByMemberId(Long memberId, Pageable pageable);
+    Slice<Trip> findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull(
+            Long memberId, Pageable pageable);
 
     long countActiveTripsByMemberIdAndCategory(Long memberId, TripCategory category);
 

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
@@ -23,11 +23,15 @@ public class TripQueryRepositoryAdapter implements TripQueryRepository {
     private final QMember member = QMember.member;
 
     @Override
-    public Slice<Trip> findSliceByMemberId(Long memberId, Pageable pageable) {
+    public Slice<Trip> findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull(
+            Long memberId, Pageable pageable) {
         List<Trip> content =
                 queryFactory
                         .selectFrom(trip)
-                        .where(trip.member.id.eq(memberId).and(trip.deletedAt.isNull()))
+                        .where(
+                                trip.member.id.eq(memberId),
+                                trip.completed.isFalse(),
+                                trip.deletedAt.isNull())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();

--- a/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
+++ b/src/main/java/com/ject/studytrip/trip/presentation/controller/TripController.java
@@ -83,7 +83,8 @@ public class TripController {
 
     @Operation(
             summary = "여행 목록 조회",
-            description = "여행 목록을 조회하는 API 입니다. 무한 스크롤을 위해 슬라이스를 적용하고, D-DAY 정보가 이른 순으로 정렬합니다.")
+            description =
+                    "여행 목록을 조회하는 API 입니다. 무한 스크롤을 위해 슬라이스를 적용하고, D-DAY 정보가 이른 순으로 정렬합니다. 완료되지 않은 여행 목록만 조회합니다.")
     @GetMapping
     public ResponseEntity<StandardResponse> loadTrips(
             @AuthenticationPrincipal String memberId,

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripQueryServiceTest.java
@@ -133,14 +133,18 @@ class TripQueryServiceTest extends BaseUnitTest {
     class GetTripsSliceByMemberId {
 
         @Test
-        @DisplayName("로그인된 사용자의 여행 목록을 DB에서 조회하고 슬라이스 처리해 반환한다")
+        @DisplayName("로그인된 사용자의 완료되지 않고 삭제되지 않은 여행 목록을 DB에서 조회하고 슬라이스 처리해 반환한다")
         void shouldGetTripsReturnSlicePaged() {
             // given
             Long memberId = member.getId();
             List<Trip> trips = List.of(trip);
             Pageable pageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
             Slice<Trip> results = new SliceImpl<>(trips, pageable, false);
-            given(tripQueryRepository.findSliceByMemberId(memberId, pageable)).willReturn(results);
+            given(
+                            tripQueryRepository
+                                    .findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull(
+                                            memberId, pageable))
+                    .willReturn(results);
 
             // when
             Slice<Trip> sliceTrips =


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
### ✅ 여행 목록 조회 리팩토링
- 요구사항을 반영해 특정 멤버의 여행 목록 조회 시 완료되지 않은 여행만 조회되도록 조건을 설정했습니다.
- `TripQueryRepository`에서 여행 목록을 조회하는 쿼리 메서드명을 **특정 멤버의 완료되지 않고 삭제되지 않은 여행을 슬라이스 처리해 조회한다**는 의미를 명확히 하기 위해 `findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull`로 수정했습니다.

### ✅ 테스트 코드 수정
- `TripQueryService` 여행 목록 조회 단위 테스트를 수정했습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #105

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-