### PR TITLE
refactor: QueryDSL Repository를 CommandRepository와 QueryRepository로 분리(#110)

### DIFF
--- a/src/main/java/com/ject/studytrip/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/ject/studytrip/member/application/service/MemberCommandService.java
@@ -8,7 +8,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.domain.model.MemberCategory;
 import com.ject.studytrip.member.domain.model.SocialProvider;
 import com.ject.studytrip.member.domain.policy.MemberPolicy;
-import com.ject.studytrip.member.domain.repository.MemberQueryRepository;
+import com.ject.studytrip.member.domain.repository.MemberCommandRepository;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import com.ject.studytrip.member.presentation.dto.request.UpdateMemberRequest;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberCommandService {
     private final MemberRepository memberRepository;
-    private final MemberQueryRepository memberQueryRepository;
+    private final MemberCommandRepository memberCommandRepository;
 
     public Member createMemberFromKakao(CreateMemberCommand command) {
         validateMemberIsUnique(SocialProvider.KAKAO, command.socialId());
@@ -52,7 +52,7 @@ public class MemberCommandService {
     }
 
     public long hardDeleteMembers() {
-        return memberQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return memberCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public void hardDeleteMemberById(Long memberId) {

--- a/src/main/java/com/ject/studytrip/member/domain/repository/MemberCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/member/domain/repository/MemberCommandRepository.java
@@ -1,0 +1,5 @@
+package com.ject.studytrip.member.domain.repository;
+
+public interface MemberCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+}

--- a/src/main/java/com/ject/studytrip/member/domain/repository/MemberQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/member/domain/repository/MemberQueryRepository.java
@@ -5,6 +5,4 @@ import java.util.Optional;
 
 public interface MemberQueryRepository {
     Optional<MemberRole> findMemberRoleById(Long memberId);
-
-    long deleteAllByDeletedAtIsNotNull();
 }

--- a/src/main/java/com/ject/studytrip/member/infra/querydsl/MemberCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/member/infra/querydsl/MemberCommandRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package com.ject.studytrip.member.infra.querydsl;
+
+import static com.ject.studytrip.member.domain.model.QMember.member;
+
+import com.ject.studytrip.member.domain.repository.MemberCommandRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberCommandRepositoryAdapter implements MemberCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(member).where(member.deletedAt.isNotNull()).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/member/infra/querydsl/MemberQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/member/infra/querydsl/MemberQueryRepositoryAdapter.java
@@ -25,9 +25,4 @@ public class MemberQueryRepositoryAdapter implements MemberQueryRepository {
 
         return Optional.ofNullable(memberRole);
     }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(member).where(member.deletedAt.isNotNull()).execute();
-    }
 }

--- a/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.mission.application.service;
 import com.ject.studytrip.mission.domain.factory.DailyMissionFactory;
 import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.mission.domain.model.Mission;
-import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.DailyMissionCommandRepository;
 import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import java.util.List;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DailyMissionCommandService {
     private final DailyMissionRepository dailyMissionRepository;
-    private final DailyMissionQueryRepository dailyMissionQueryRepository;
+    private final DailyMissionCommandRepository dailyMissionCommandRepository;
 
     public List<DailyMission> createDailyMissions(DailyGoal dailyGoal, List<Mission> missions) {
         List<DailyMission> dailyMissions =
@@ -30,18 +30,18 @@ public class DailyMissionCommandService {
     }
 
     public long hardDeleteDailyMissions() {
-        return dailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return dailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteDailyMissionsOwnedByDeletedMission() {
-        return dailyMissionQueryRepository.deleteAllByDeletedMissionOwner();
+        return dailyMissionCommandRepository.deleteAllByDeletedMissionOwner();
     }
 
     public long hardDeleteDailyMissionsOwnedByDeletedDailyGoal() {
-        return dailyMissionQueryRepository.deleteAllByDeletedDailyGoalOwner();
+        return dailyMissionCommandRepository.deleteAllByDeletedDailyGoalOwner();
     }
 
     public long hardDeleteDailyMissionsByMember(Long memberId) {
-        return dailyMissionQueryRepository.deleteAllByMemberId(memberId);
+        return dailyMissionCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.mission.application.service;
 import com.ject.studytrip.mission.domain.factory.MissionFactory;
 import com.ject.studytrip.mission.domain.model.Mission;
 import com.ject.studytrip.mission.domain.policy.MissionPolicy;
-import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.MissionCommandRepository;
 import com.ject.studytrip.mission.domain.repository.MissionRepository;
 import com.ject.studytrip.mission.presentation.dto.request.CreateMissionRequest;
 import com.ject.studytrip.mission.presentation.dto.request.UpdateMissionRequest;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MissionCommandService {
     private final MissionRepository missionRepository;
-    private final MissionQueryRepository missionQueryRepository;
+    private final MissionCommandRepository missionCommandRepository;
 
     public Mission createMission(Stamp stamp, CreateMissionRequest request) {
         Mission mission = MissionFactory.create(stamp, request.missionName());
@@ -47,20 +47,20 @@ public class MissionCommandService {
 
     public void validateAllMissionsCompletedByStampId(Long stampId) {
         boolean exists =
-                missionQueryRepository.existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(
+                missionCommandRepository.existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(
                         stampId);
         MissionPolicy.validateAllCompleted(exists);
     }
 
     public long hardDeleteMissions() {
-        return missionQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return missionCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteMissionsOwnedByDeletedStamp() {
-        return missionQueryRepository.deleteAllByDeletedStampOwner();
+        return missionCommandRepository.deleteAllByDeletedStampOwner();
     }
 
     public long hardDeleteMissionsByMember(Long memberId) {
-        return missionQueryRepository.deleteAllByMemberId(memberId);
+        return missionCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionCommandRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.mission.domain.repository;
+
+public interface DailyMissionCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedMissionOwner();
+
+    long deleteAllByDeletedDailyGoalOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
@@ -7,12 +7,4 @@ public interface DailyMissionQueryRepository {
     List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId);
 
     List<DailyMission> findAllWithMissionAndStampByIds(List<Long> ids);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedMissionOwner();
-
-    long deleteAllByDeletedDailyGoalOwner();
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/MissionCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/MissionCommandRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.mission.domain.repository;
+
+public interface MissionCommandRepository {
+    boolean existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(Long stampId);
+
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedStampOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
@@ -5,12 +5,4 @@ import java.util.List;
 
 public interface MissionQueryRepository {
     List<Mission> findAllByIdsInFetchJoinStamp(List<Long> ids);
-
-    boolean existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(Long stampId);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedStampOwner();
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionCommandRepositoryAdapter.java
@@ -1,0 +1,69 @@
+package com.ject.studytrip.mission.infra.querydsl;
+
+import static com.ject.studytrip.mission.domain.model.QDailyMission.dailyMission;
+import static com.ject.studytrip.mission.domain.model.QMission.mission;
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.mission.domain.repository.DailyMissionCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyMissionCommandRepositoryAdapter implements DailyMissionCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory
+                .delete(dailyMission)
+                .where(dailyMission.deletedAt.isNotNull())
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedMissionOwner() {
+        return queryFactory
+                .delete(dailyMission)
+                .where(
+                        dailyMission.mission.id.in(
+                                JPAExpressions.select(mission.id)
+                                        .from(mission)
+                                        .where(mission.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedDailyGoalOwner() {
+        return queryFactory
+                .delete(dailyMission)
+                .where(
+                        dailyMission.dailyGoal.id.in(
+                                JPAExpressions.select(dailyGoal.id)
+                                        .from(dailyGoal)
+                                        .where(dailyGoal.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(dailyMission.id)
+                        .from(dailyMission)
+                        .join(dailyMission.mission, mission)
+                        .join(mission.stamp, stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(dailyMission).where(dailyMission.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
@@ -1,13 +1,11 @@
 package com.ject.studytrip.mission.infra.querydsl;
 
+import static com.ject.studytrip.mission.domain.model.QDailyMission.dailyMission;
+import static com.ject.studytrip.mission.domain.model.QMission.mission;
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+
 import com.ject.studytrip.mission.domain.model.DailyMission;
-import com.ject.studytrip.mission.domain.model.QDailyMission;
-import com.ject.studytrip.mission.domain.model.QMission;
 import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
-import com.ject.studytrip.stamp.domain.model.QStamp;
-import com.ject.studytrip.trip.domain.model.QDailyGoal;
-import com.ject.studytrip.trip.domain.model.QTrip;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +15,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QDailyMission dailyMission = QDailyMission.dailyMission;
-    private final QTrip trip = QTrip.trip;
-    private final QStamp stamp = QStamp.stamp;
-    private final QMission mission = QMission.mission;
-    private final QDailyGoal dailyGoal = QDailyGoal.dailyGoal;
 
     @Override
     public List<DailyMission> findAllByDailyGoalIdFetchJoinMission(Long dailyGoalId) {
@@ -43,54 +36,5 @@ public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepo
                 .fetchJoin()
                 .where(dailyMission.id.in(ids))
                 .fetch();
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory
-                .delete(dailyMission)
-                .where(dailyMission.deletedAt.isNotNull())
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedMissionOwner() {
-        return queryFactory
-                .delete(dailyMission)
-                .where(
-                        dailyMission.mission.id.in(
-                                JPAExpressions.select(mission.id)
-                                        .from(mission)
-                                        .where(mission.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedDailyGoalOwner() {
-        return queryFactory
-                .delete(dailyMission)
-                .where(
-                        dailyMission.dailyGoal.id.in(
-                                JPAExpressions.select(dailyGoal.id)
-                                        .from(dailyGoal)
-                                        .where(dailyGoal.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(dailyMission.id)
-                        .from(dailyMission)
-                        .join(dailyMission.mission, mission)
-                        .join(mission.stamp, stamp)
-                        .join(stamp.trip, trip)
-                        .where(trip.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory.delete(dailyMission).where(dailyMission.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionCommandRepositoryAdapter.java
@@ -1,0 +1,66 @@
+package com.ject.studytrip.mission.infra.querydsl;
+
+import static com.ject.studytrip.mission.domain.model.QMission.mission;
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.mission.domain.repository.MissionCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionCommandRepositoryAdapter implements MissionCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(Long stampId) {
+        Integer hit =
+                queryFactory
+                        .selectOne()
+                        .from(mission)
+                        .where(
+                                mission.stamp.id.eq(stampId),
+                                mission.completed.isFalse(),
+                                mission.deletedAt.isNull())
+                        .fetchFirst();
+
+        return hit != null;
+    }
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(mission).where(mission.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedStampOwner() {
+        return queryFactory
+                .delete(mission)
+                .where(
+                        mission.stamp.id.in(
+                                JPAExpressions.select(stamp.id)
+                                        .from(stamp)
+                                        .where(stamp.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(mission.id)
+                        .from(mission)
+                        .join(mission.stamp, stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(mission).where(mission.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionQueryRepositoryAdapter.java
@@ -1,11 +1,10 @@
 package com.ject.studytrip.mission.infra.querydsl;
 
+import static com.ject.studytrip.mission.domain.model.QMission.mission;
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+
 import com.ject.studytrip.mission.domain.model.Mission;
-import com.ject.studytrip.mission.domain.model.QMission;
 import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
-import com.ject.studytrip.stamp.domain.model.QStamp;
-import com.ject.studytrip.trip.domain.model.QTrip;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +14,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class MissionQueryRepositoryAdapter implements MissionQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QMission mission = QMission.mission;
-    private final QStamp stamp = QStamp.stamp;
-    private final QTrip trip = QTrip.trip;
 
     @Override
     public List<Mission> findAllByIdsInFetchJoinStamp(List<Long> ids) {
@@ -27,53 +23,5 @@ public class MissionQueryRepositoryAdapter implements MissionQueryRepository {
                 .fetchJoin()
                 .where(mission.id.in(ids))
                 .fetch();
-    }
-
-    @Override
-    public boolean existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(Long stampId) {
-        Integer hit =
-                queryFactory
-                        .selectOne()
-                        .from(mission)
-                        .where(
-                                mission.stamp.id.eq(stampId),
-                                mission.completed.isFalse(),
-                                mission.deletedAt.isNull())
-                        .fetchFirst();
-
-        return hit != null;
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(mission).where(mission.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedStampOwner() {
-        return queryFactory
-                .delete(mission)
-                .where(
-                        mission.stamp.id.in(
-                                JPAExpressions.select(stamp.id)
-                                        .from(stamp)
-                                        .where(stamp.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(mission.id)
-                        .from(mission)
-                        .join(mission.stamp, stamp)
-                        .join(stamp.trip, trip)
-                        .where(trip.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory.delete(mission).where(mission.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandService.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.pomodoro.application.service;
 import com.ject.studytrip.pomodoro.domain.factory.PomodoroFactory;
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
 import com.ject.studytrip.pomodoro.domain.policy.PomodoroPolicy;
-import com.ject.studytrip.pomodoro.domain.repository.PomodoroQueryRepository;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroCommandRepository;
 import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
 import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PomodoroCommandService {
     private final PomodoroRepository pomodoroRepository;
-    private final PomodoroQueryRepository pomodoroQueryRepository;
+    private final PomodoroCommandRepository pomodoroCommandRepository;
 
     public Pomodoro createPomodoro(DailyGoal dailyGoal, CreatePomodoroRequest request) {
         int focusDurationInSeconds = request.focusDurationInMinute() * 60;
@@ -37,14 +37,14 @@ public class PomodoroCommandService {
     }
 
     public long hardDeletePomodoros() {
-        return pomodoroQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return pomodoroCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeletePomodorosOwnedByDeletedDailyGoal() {
-        return pomodoroQueryRepository.deleteAllByDeletedDailyGoalOwner();
+        return pomodoroCommandRepository.deleteAllByDeletedDailyGoalOwner();
     }
 
     public long hardDeletePomodorosByMember(Long memberId) {
-        return pomodoroQueryRepository.deleteAllByMemberId(memberId);
+        return pomodoroCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroCommandRepository.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.pomodoro.domain.repository;
+
+public interface PomodoroCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedDailyGoalOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroQueryRepository.java
@@ -1,11 +1,5 @@
 package com.ject.studytrip.pomodoro.domain.repository;
 
 public interface PomodoroQueryRepository {
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedDailyGoalOwner();
-
     long sumFocusHoursByTripId(Long tripId);
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroCommandRepositoryAdapter.java
@@ -1,0 +1,51 @@
+package com.ject.studytrip.pomodoro.infra.querydsl;
+
+import static com.ject.studytrip.pomodoro.domain.model.QPomodoro.pomodoro;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PomodoroCommandRepositoryAdapter implements PomodoroCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(pomodoro).where(pomodoro.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedDailyGoalOwner() {
+        return queryFactory
+                .delete(pomodoro)
+                .where(
+                        pomodoro.dailyGoal.id.in(
+                                JPAExpressions.select(dailyGoal.id)
+                                        .from(dailyGoal)
+                                        .where(dailyGoal.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(pomodoro.id)
+                        .from(pomodoro)
+                        .join(pomodoro.dailyGoal, dailyGoal)
+                        .join(dailyGoal.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(pomodoro).where(pomodoro.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroQueryRepositoryAdapter.java
@@ -1,12 +1,11 @@
 package com.ject.studytrip.pomodoro.infra.querydsl;
 
-import com.ject.studytrip.pomodoro.domain.model.QPomodoro;
+import static com.ject.studytrip.pomodoro.domain.model.QPomodoro.pomodoro;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
 import com.ject.studytrip.pomodoro.domain.repository.PomodoroQueryRepository;
-import com.ject.studytrip.trip.domain.model.QDailyGoal;
-import com.ject.studytrip.trip.domain.model.QTrip;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,26 +13,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class PomodoroQueryRepositoryAdapter implements PomodoroQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QPomodoro pomodoro = QPomodoro.pomodoro;
-    private final QDailyGoal dailyGoal = QDailyGoal.dailyGoal;
-    private final QTrip trip = QTrip.trip;
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(pomodoro).where(pomodoro.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedDailyGoalOwner() {
-        return queryFactory
-                .delete(pomodoro)
-                .where(
-                        pomodoro.dailyGoal.id.in(
-                                JPAExpressions.select(dailyGoal.id)
-                                        .from(dailyGoal)
-                                        .where(dailyGoal.deletedAt.isNotNull())))
-                .execute();
-    }
 
     @Override
     public long sumFocusHoursByTripId(Long tripId) {
@@ -53,21 +32,5 @@ public class PomodoroQueryRepositoryAdapter implements PomodoroQueryRepository {
         long seconds = totalSeconds == null ? 0L : totalSeconds.longValue();
 
         return seconds / 3600L; // 정수 시간(내림)
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(pomodoro.id)
-                        .from(pomodoro)
-                        .join(pomodoro.dailyGoal, dailyGoal)
-                        .join(dailyGoal.trip, trip)
-                        .where(trip.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory.delete(pomodoro).where(pomodoro.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/facade/StampFacade.java
@@ -18,6 +18,7 @@ import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampRequest;
 import com.ject.studytrip.trip.application.service.TripCommandService;
 import com.ject.studytrip.trip.application.service.TripQueryService;
 import com.ject.studytrip.trip.domain.model.Trip;
+import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -52,7 +53,8 @@ public class StampFacade {
     @Transactional
     public StampInfo createStamp(Long memberId, Long tripId, CreateStampRequest request) {
         Trip trip = tripQueryService.getValidTrip(memberId, tripId);
-        Stamp stamp = stampCommandService.createStamp(trip, request);
+        int nextOrder = stampQueryService.getNextStampOrderByTrip(trip);
+        Stamp stamp = stampCommandService.createStamp(trip, nextOrder, request);
         tripCommandService.increaseTotalStamps(trip);
 
         return StampInfo.from(stamp);
@@ -123,7 +125,8 @@ public class StampFacade {
         Trip trip = tripQueryService.getValidTrip(memberId, tripId);
         Stamp stamp = stampQueryService.getValidStamp(trip.getId(), stampId);
 
-        stampCommandService.deleteStamp(trip.getId(), trip.getCategory(), stamp);
+        stampCommandService.deleteStamp(stamp);
+        shiftStampOrdersIfTripCategoryIsCourse(trip, stamp.getStampOrder());
         tripCommandService.decreaseTotalStamps(trip);
     }
 
@@ -178,5 +181,14 @@ public class StampFacade {
 
         stampCommandService.completeStamp(stamp);
         tripCommandService.increaseCompletedStamps(trip);
+    }
+
+    private void shiftStampOrdersIfTripCategoryIsCourse(Trip trip, int stampOrder) {
+        if (trip.getCategory() != TripCategory.COURSE) return;
+
+        List<Stamp> affectedStamps =
+                stampQueryService.getStampsToShiftAfterDeleted(trip.getId(), stampOrder);
+
+        stampCommandService.shiftStampOrders(affectedStamps);
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.stamp.application.service;
 import com.ject.studytrip.stamp.domain.factory.StampFactory;
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.policy.StampPolicy;
-import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
+import com.ject.studytrip.stamp.domain.repository.StampCommandRepository;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
 import com.ject.studytrip.stamp.presentation.dto.request.CreateStampRequest;
 import com.ject.studytrip.stamp.presentation.dto.request.UpdateStampOrderRequest;
@@ -21,21 +21,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StampCommandService {
     private final StampRepository stampRepository;
-    private final StampQueryRepository stampQueryRepository;
+    private final StampCommandRepository stampCommandRepository;
 
-    public Stamp createStamp(Trip trip, CreateStampRequest request) {
-        int nextOrder = 0;
-        if (trip.getCategory() == TripCategory.COURSE) {
-            nextOrder = computeNextStampOrder(trip.getId());
-        }
-
+    public Stamp createStamp(Trip trip, int nextOrder, CreateStampRequest request) {
         Stamp stamp = StampFactory.create(trip, request.name(), nextOrder, request.endDate());
         StampPolicy.validateEndDate(trip.getEndDate(), stamp.getEndDate());
 
         return stampRepository.save(stamp);
     }
 
-    public void createStamps(Trip trip, List<CreateStampRequest> requests) {
+    public void createStamps(Trip trip, int nextOrder, List<CreateStampRequest> requests) {
         if (requests == null || requests.isEmpty()) return;
 
         final List<Stamp> stamps =
@@ -52,13 +47,13 @@ public class StampCommandService {
                         // 코스형 여행일 경우
                         // nextOrder 부터 1씩 증가하며 order 저장
                     case COURSE -> {
-                        int nextOrder = computeNextStampOrder(trip.getId());
+                        int order = nextOrder;
 
                         List<Stamp> stampList = new ArrayList<>();
                         for (CreateStampRequest request : requests) {
                             Stamp stamp =
                                     StampFactory.create(
-                                            trip, request.name(), nextOrder++, request.endDate());
+                                            trip, request.name(), order++, request.endDate());
                             stampList.add(stamp);
                         }
 
@@ -118,12 +113,8 @@ public class StampCommandService {
         }
     }
 
-    public void deleteStamp(Long tripId, TripCategory tripCategory, Stamp stamp) {
+    public void deleteStamp(Stamp stamp) {
         stamp.updateDeletedAt();
-
-        if (tripCategory == TripCategory.COURSE) {
-            shiftStampOrdersAfterDeleted(tripId, stamp.getStampOrder());
-        }
     }
 
     public void completeStamp(Stamp stamp) {
@@ -132,31 +123,29 @@ public class StampCommandService {
         stamp.updateCompleted();
     }
 
+    public void shiftStampOrders(List<Stamp> affectedStamps) {
+        for (Stamp stamp : affectedStamps) {
+            stamp.updateStampOrder(stamp.getStampOrder() - 1);
+        }
+    }
+
     public void validateStampBelongsToTrip(Long tripId, Stamp stamp) {
         StampPolicy.validateStampBelongsToTrip(tripId, stamp);
     }
 
     public void validateAllStampsCompletedByTripId(Long tripId) {
         boolean exists =
-                stampQueryRepository.existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId);
+                stampCommandRepository.existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId);
+
         StampPolicy.validateAllCompleted(exists);
     }
 
     public long hardDeleteStamps() {
-        return stampQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return stampCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteStampsOwnedByDeletedTrip() {
-        return stampQueryRepository.deleteAllByDeletedTripOwner();
-    }
-
-    private void shiftStampOrdersAfterDeleted(Long tripId, int deletedStampOrder) {
-        List<Stamp> affectedStamps =
-                stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedStampOrder);
-
-        for (Stamp stamp : affectedStamps) {
-            stamp.updateStampOrder(stamp.getStampOrder() - 1);
-        }
+        return stampCommandRepository.deleteAllByDeletedTripOwner();
     }
 
     public void increaseTotalMissions(Stamp stamp) {
@@ -171,12 +160,7 @@ public class StampCommandService {
         stamp.increaseCompletedMissions(count);
     }
 
-    private int computeNextStampOrder(Long tripId) {
-        Integer lastOrder = stampQueryRepository.findMaxStampOrderByTripId(tripId);
-        return lastOrder == null ? 1 : lastOrder + 1;
-    }
-
     public long hardDeleteStampsByMember(Long memberId) {
-        return stampQueryRepository.deleteAllByMemberId(memberId);
+        return stampCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampQueryService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampQueryService.java
@@ -6,6 +6,7 @@ import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.policy.StampPolicy;
 import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
+import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import java.util.Comparator;
 import java.util.List;
@@ -55,6 +56,18 @@ public class StampQueryService {
         }
 
         return getExplorationStampName(stamps);
+    }
+
+    public int getNextStampOrderByTrip(Trip trip) {
+        if (trip.getCategory() != TripCategory.COURSE) {
+            return 0;
+        }
+
+        return stampQueryRepository.findNextStampOrderByTripId(trip.getId());
+    }
+
+    public List<Stamp> getStampsToShiftAfterDeleted(Long tripId, int deletedStampOrder) {
+        return stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedStampOrder);
     }
 
     private String getExplorationStampName(List<Stamp> stamps) {

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampCommandRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.stamp.domain.repository;
+
+public interface StampCommandRepository {
+    boolean existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(Long tripId);
+
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedTripOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
@@ -9,13 +9,5 @@ public interface StampQueryRepository {
 
     Optional<Stamp> findFirstIncompleteStampByTripId(Long tripId);
 
-    boolean existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(Long tripId);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedTripOwner();
-
-    Integer findMaxStampOrderByTripId(Long tripId);
-
-    long deleteAllByMemberId(Long memberId);
+    int findNextStampOrderByTripId(Long tripId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampCommandRepositoryAdapter.java
@@ -1,0 +1,64 @@
+package com.ject.studytrip.stamp.infra.querydsl;
+
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.stamp.domain.repository.StampCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StampCommandRepositoryAdapter implements StampCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(Long tripId) {
+        Integer hit =
+                queryFactory
+                        .selectOne()
+                        .from(stamp)
+                        .where(
+                                stamp.trip.id.eq(tripId),
+                                stamp.completed.isFalse(),
+                                stamp.deletedAt.isNull())
+                        .fetchOne();
+
+        return hit != null;
+    }
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(stamp).where(stamp.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedTripOwner() {
+        return queryFactory
+                .delete(stamp)
+                .where(
+                        stamp.trip.id.in(
+                                JPAExpressions.select(trip.id)
+                                        .from(trip)
+                                        .where(trip.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(stamp.id)
+                        .from(stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(stamp).where(stamp.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
@@ -1,10 +1,9 @@
 package com.ject.studytrip.stamp.infra.querydsl;
 
-import com.ject.studytrip.stamp.domain.model.QStamp;
+import static com.ject.studytrip.stamp.domain.model.QStamp.stamp;
+
 import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
-import com.ject.studytrip.trip.domain.model.QTrip;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -15,8 +14,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class StampQueryRepositoryAdapter implements StampQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QStamp stamp = QStamp.stamp;
-    private final QTrip trip = QTrip.trip;
 
     @Override
     public List<Stamp> findStampsToShiftAfterOrder(Long tripId, int deletedOrder) {
@@ -45,58 +42,14 @@ public class StampQueryRepositoryAdapter implements StampQueryRepository {
     }
 
     @Override
-    public boolean existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(Long tripId) {
-        Integer hit =
+    public int findNextStampOrderByTripId(Long tripId) {
+        Integer lastOrder =
                 queryFactory
-                        .selectOne()
+                        .select(stamp.stampOrder.max().coalesce(0))
                         .from(stamp)
-                        .where(
-                                stamp.trip.id.eq(tripId),
-                                stamp.completed.isFalse(),
-                                stamp.deletedAt.isNull())
+                        .where(stamp.trip.id.eq(tripId), stamp.deletedAt.isNull())
                         .fetchOne();
 
-        return hit != null;
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(stamp).where(stamp.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedTripOwner() {
-        return queryFactory
-                .delete(stamp)
-                .where(
-                        stamp.trip.id.in(
-                                JPAExpressions.select(trip.id)
-                                        .from(trip)
-                                        .where(trip.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public Integer findMaxStampOrderByTripId(Long tripId) {
-        return queryFactory
-                .select(stamp.stampOrder.max().coalesce(0))
-                .from(stamp)
-                .where(stamp.trip.id.eq(tripId), stamp.deletedAt.isNull())
-                .fetchOne();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(stamp.id)
-                        .from(stamp)
-                        .join(stamp.trip, trip)
-                        .where(trip.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory.delete(stamp).where(stamp.id.in(ids)).execute();
+        return lastOrder != null ? lastOrder + 1 : 1;
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogCommandService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogCommandService.java
@@ -4,7 +4,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.studylog.domain.factory.StudyLogFactory;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.domain.policy.StudyLogPolicy;
-import com.ject.studytrip.studylog.domain.repository.StudyLogQueryRepository;
+import com.ject.studytrip.studylog.domain.repository.StudyLogCommandRepository;
 import com.ject.studytrip.studylog.domain.repository.StudyLogRepository;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StudyLogCommandService {
     private final StudyLogRepository studyLogRepository;
-    private final StudyLogQueryRepository studyLogQueryRepository;
+    private final StudyLogCommandRepository studyLogCommandRepository;
 
     public StudyLog createStudyLog(Member member, DailyGoal dailyGoal, String content) {
         StudyLog studyLog = StudyLogFactory.create(member, dailyGoal, content);
@@ -23,15 +23,15 @@ public class StudyLogCommandService {
     }
 
     public long hardDeleteStudyLogs() {
-        return studyLogQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return studyLogCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteStudyLogsOwnedByDeletedMember() {
-        return studyLogQueryRepository.deleteAllByDeletedMemberOwner();
+        return studyLogCommandRepository.deleteAllByDeletedMemberOwner();
     }
 
     public long hardDeleteStudyLogsOwnedByDeletedDailyGoal() {
-        return studyLogQueryRepository.deleteAllByDeletedDailyGoalOwner();
+        return studyLogCommandRepository.deleteAllByDeletedDailyGoalOwner();
     }
 
     public void updateImageUrl(StudyLog studyLog, String imageUrl) {
@@ -41,6 +41,6 @@ public class StudyLogCommandService {
     }
 
     public long hardDeleteStudyLogsByMember(Long memberId) {
-        return studyLogQueryRepository.deleteByMemberId(memberId);
+        return studyLogCommandRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandService.java
@@ -4,7 +4,7 @@ import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.studylog.domain.factory.StudyLogDailyMissionFactory;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.domain.model.StudyLogDailyMission;
-import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionQueryRepository;
+import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionCommandRepository;
 import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StudyLogDailyMissionCommandService {
     private final StudyLogDailyMissionRepository studyLogDailyMissionRepository;
-    private final StudyLogDailyMissionQueryRepository studyLogDailyMissionQueryRepository;
+    private final StudyLogDailyMissionCommandRepository studyLogDailyMissionCommandRepository;
 
     public List<StudyLogDailyMission> createStudyLogDailyMissions(
             StudyLog studyLog, List<DailyMission> dailyMissions) {
@@ -29,18 +29,18 @@ public class StudyLogDailyMissionCommandService {
     }
 
     public long hardDeleteStudyLogDailyMissions() {
-        return studyLogDailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return studyLogDailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteStudyLogDailyMissionsOwnedByDeletedDailyMission() {
-        return studyLogDailyMissionQueryRepository.deleteAllByDeletedDailyMissionOwner();
+        return studyLogDailyMissionCommandRepository.deleteAllByDeletedDailyMissionOwner();
     }
 
     public long hardDeleteStudyLogDailyMissionsOwnedByDeletedStudyLog() {
-        return studyLogDailyMissionQueryRepository.deleteAllByDeletedStudyLogOwner();
+        return studyLogDailyMissionCommandRepository.deleteAllByDeletedStudyLogOwner();
     }
 
     public long hardDeleteStudyLogDailyMissionsByMember(Long memberId) {
-        return studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId);
+        return studyLogDailyMissionCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogCommandRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.studylog.domain.repository;
+
+public interface StudyLogCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedMemberOwner();
+
+    long deleteAllByDeletedDailyGoalOwner();
+
+    long deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionCommandRepository.java
@@ -1,0 +1,11 @@
+package com.ject.studytrip.studylog.domain.repository;
+
+public interface StudyLogDailyMissionCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedDailyMissionOwner();
+
+    long deleteAllByDeletedStudyLogOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionQueryRepository.java
@@ -7,12 +7,4 @@ import java.util.Map;
 public interface StudyLogDailyMissionQueryRepository {
     Map<Long, List<StudyLogDailyMission>> findStudyLogDailyMissionsGroupedByStudyLogId(
             List<Long> studyLogIds);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedDailyMissionOwner();
-
-    long deleteAllByDeletedStudyLogOwner();
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
@@ -6,17 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface StudyLogQueryRepository {
-    long countActiveStudyLogsByMemberId(Long memberId);
-
     Slice<StudyLog> findSliceByTripId(Long tripId, Pageable pageable, String order);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedMemberOwner();
-
-    long deleteAllByDeletedDailyGoalOwner();
-
-    long countStudyLogsByTripId(Long tripId);
 
     Slice<StudyLog> findSliceByTripReportIdOrderByCreatedAtDesc(
             Long tripReportId, Pageable pageable);
@@ -25,5 +15,7 @@ public interface StudyLogQueryRepository {
 
     List<String> findImageUrlsByMemberId(Long memberId);
 
-    long deleteByMemberId(Long memberId);
+    long countStudyLogsByTripId(Long tripId);
+
+    long countActiveStudyLogsByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogCommandRepositoryAdapter.java
@@ -1,0 +1,51 @@
+package com.ject.studytrip.studylog.infra.querydsl;
+
+import static com.ject.studytrip.member.domain.model.QMember.member;
+import static com.ject.studytrip.studylog.domain.model.QStudyLog.studyLog;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+
+import com.ject.studytrip.studylog.domain.repository.StudyLogCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyLogCommandRepositoryAdapter implements StudyLogCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(studyLog).where(studyLog.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedMemberOwner() {
+        return queryFactory
+                .delete(studyLog)
+                .where(
+                        studyLog.member.id.in(
+                                JPAExpressions.select(member.id)
+                                        .from(member)
+                                        .where(member.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedDailyGoalOwner() {
+        return queryFactory
+                .delete(studyLog)
+                .where(
+                        studyLog.dailyGoal.id.in(
+                                JPAExpressions.select(dailyGoal.id)
+                                        .from(dailyGoal)
+                                        .where(dailyGoal.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteByMemberId(Long memberId) {
+        return queryFactory.delete(studyLog).where(studyLog.member.id.eq(memberId)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionCommandRepositoryAdapter.java
@@ -1,0 +1,69 @@
+package com.ject.studytrip.studylog.infra.querydsl;
+
+import static com.ject.studytrip.mission.domain.model.QDailyMission.dailyMission;
+import static com.ject.studytrip.studylog.domain.model.QStudyLog.studyLog;
+import static com.ject.studytrip.studylog.domain.model.QStudyLogDailyMission.studyLogDailyMission;
+
+import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyLogDailyMissionCommandRepositoryAdapter
+        implements StudyLogDailyMissionCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory
+                .delete(studyLogDailyMission)
+                .where(studyLogDailyMission.deletedAt.isNotNull())
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedDailyMissionOwner() {
+        return queryFactory
+                .delete(studyLogDailyMission)
+                .where(
+                        studyLogDailyMission.dailyMission.id.in(
+                                JPAExpressions.select(dailyMission.id)
+                                        .from(dailyMission)
+                                        .where(dailyMission.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedStudyLogOwner() {
+        return queryFactory
+                .delete(studyLogDailyMission)
+                .where(
+                        studyLogDailyMission.studyLog.id.in(
+                                JPAExpressions.select(studyLog.id)
+                                        .from(studyLog)
+                                        .where(studyLog.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(studyLogDailyMission.id)
+                        .from(studyLogDailyMission)
+                        .join(studyLogDailyMission.studyLog, studyLog)
+                        .where(studyLog.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory
+                .delete(studyLogDailyMission)
+                .where(studyLogDailyMission.id.in(ids))
+                .execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionQueryRepositoryAdapter.java
@@ -1,12 +1,11 @@
 package com.ject.studytrip.studylog.infra.querydsl;
 
-import com.ject.studytrip.mission.domain.model.QDailyMission;
-import com.ject.studytrip.mission.domain.model.QMission;
-import com.ject.studytrip.studylog.domain.model.QStudyLog;
-import com.ject.studytrip.studylog.domain.model.QStudyLogDailyMission;
+import static com.ject.studytrip.mission.domain.model.QDailyMission.dailyMission;
+import static com.ject.studytrip.mission.domain.model.QMission.mission;
+import static com.ject.studytrip.studylog.domain.model.QStudyLogDailyMission.studyLogDailyMission;
+
 import com.ject.studytrip.studylog.domain.model.StudyLogDailyMission;
 import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionQueryRepository;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Map;
@@ -19,11 +18,6 @@ import org.springframework.stereotype.Repository;
 public class StudyLogDailyMissionQueryRepositoryAdapter
         implements StudyLogDailyMissionQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QStudyLogDailyMission studyLogDailyMission =
-            QStudyLogDailyMission.studyLogDailyMission;
-    private final QDailyMission dailyMission = QDailyMission.dailyMission;
-    private final QMission mission = QMission.mission;
-    private final QStudyLog studyLog = QStudyLog.studyLog;
 
     @Override
     public Map<Long, List<StudyLogDailyMission>> findStudyLogDailyMissionsGroupedByStudyLogId(
@@ -38,55 +32,5 @@ public class StudyLogDailyMissionQueryRepositoryAdapter
                 .fetch()
                 .stream()
                 .collect(Collectors.groupingBy(sldm -> sldm.getStudyLog().getId()));
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory
-                .delete(studyLogDailyMission)
-                .where(studyLogDailyMission.deletedAt.isNotNull())
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedDailyMissionOwner() {
-        return queryFactory
-                .delete(studyLogDailyMission)
-                .where(
-                        studyLogDailyMission.dailyMission.id.in(
-                                JPAExpressions.select(dailyMission.id)
-                                        .from(dailyMission)
-                                        .where(dailyMission.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedStudyLogOwner() {
-        return queryFactory
-                .delete(studyLogDailyMission)
-                .where(
-                        studyLogDailyMission.studyLog.id.in(
-                                JPAExpressions.select(studyLog.id)
-                                        .from(studyLog)
-                                        .where(studyLog.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(studyLogDailyMission.id)
-                        .from(studyLogDailyMission)
-                        .join(studyLogDailyMission.studyLog, studyLog)
-                        .where(studyLog.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory
-                .delete(studyLogDailyMission)
-                .where(studyLogDailyMission.id.in(ids))
-                .execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
@@ -1,13 +1,12 @@
 package com.ject.studytrip.studylog.infra.querydsl;
 
-import com.ject.studytrip.member.domain.model.QMember;
-import com.ject.studytrip.studylog.domain.model.QStudyLog;
+import static com.ject.studytrip.studylog.domain.model.QStudyLog.studyLog;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+import static com.ject.studytrip.trip.domain.model.QTripReportStudyLog.tripReportStudyLog;
+
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.domain.repository.StudyLogQueryRepository;
-import com.ject.studytrip.trip.domain.model.QDailyGoal;
-import com.ject.studytrip.trip.domain.model.QTripReportStudyLog;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -21,22 +20,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class StudyLogQueryRepositoryAdapter implements StudyLogQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QStudyLog studyLog = QStudyLog.studyLog;
-    private final QDailyGoal dailyGoal = QDailyGoal.dailyGoal;
-    private final QMember member = QMember.member;
-    private final QTripReportStudyLog tripReportStudyLog = QTripReportStudyLog.tripReportStudyLog;
-
-    @Override
-    public long countActiveStudyLogsByMemberId(Long memberId) {
-        Long count =
-                queryFactory
-                        .select(studyLog.count())
-                        .from(studyLog)
-                        .where(studyLog.member.id.eq(memberId).and(studyLog.deletedAt.isNull()))
-                        .fetchOne();
-
-        return Optional.ofNullable(count).orElse(0L);
-    }
 
     @Override
     public Slice<StudyLog> findSliceByTripId(Long tripId, Pageable pageable, String order) {
@@ -57,51 +40,6 @@ public class StudyLogQueryRepositoryAdapter implements StudyLogQueryRepository {
         }
 
         return new SliceImpl<>(result, pageable, hasNext);
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(studyLog).where(studyLog.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedMemberOwner() {
-        return queryFactory
-                .delete(studyLog)
-                .where(
-                        studyLog.member.id.in(
-                                JPAExpressions.select(member.id)
-                                        .from(member)
-                                        .where(member.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedDailyGoalOwner() {
-        return queryFactory
-                .delete(studyLog)
-                .where(
-                        studyLog.dailyGoal.id.in(
-                                JPAExpressions.select(dailyGoal.id)
-                                        .from(dailyGoal)
-                                        .where(dailyGoal.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long countStudyLogsByTripId(Long tripId) {
-        Long count =
-                queryFactory
-                        .select(studyLog.count())
-                        .from(studyLog)
-                        .join(studyLog.dailyGoal, dailyGoal)
-                        .where(
-                                dailyGoal.trip.id.eq(tripId),
-                                studyLog.deletedAt.isNull(),
-                                dailyGoal.deletedAt.isNull())
-                        .fetchOne();
-
-        return count == null ? 0L : count;
     }
 
     @Override
@@ -150,8 +88,31 @@ public class StudyLogQueryRepositoryAdapter implements StudyLogQueryRepository {
     }
 
     @Override
-    public long deleteByMemberId(Long memberId) {
-        return queryFactory.delete(studyLog).where(studyLog.member.id.eq(memberId)).execute();
+    public long countStudyLogsByTripId(Long tripId) {
+        Long count =
+                queryFactory
+                        .select(studyLog.count())
+                        .from(studyLog)
+                        .join(studyLog.dailyGoal, dailyGoal)
+                        .where(
+                                dailyGoal.trip.id.eq(tripId),
+                                studyLog.deletedAt.isNull(),
+                                dailyGoal.deletedAt.isNull())
+                        .fetchOne();
+
+        return count == null ? 0L : count;
+    }
+
+    @Override
+    public long countActiveStudyLogsByMemberId(Long memberId) {
+        Long count =
+                queryFactory
+                        .select(studyLog.count())
+                        .from(studyLog)
+                        .where(studyLog.member.id.eq(memberId).and(studyLog.deletedAt.isNull()))
+                        .fetchOne();
+
+        return Optional.ofNullable(count).orElse(0L);
     }
 
     private OrderSpecifier<?>[] orderSpecifiers(String order) {

--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripFacade.java
@@ -51,7 +51,8 @@ public class TripFacade {
     public TripInfo createTrip(Long memberId, CreateTripRequest request) {
         Member member = memberQueryService.getValidMember(memberId);
         Trip trip = tripCommandService.createTrip(member, request);
-        stampCommandService.createStamps(trip, request.stamps());
+        int nextOrder = stampQueryService.getNextStampOrderByTrip(trip);
+        stampCommandService.createStamps(trip, nextOrder, request.stamps());
 
         return TripInfo.from(trip, null, null);
     }

--- a/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.trip.application.service;
 import com.ject.studytrip.trip.domain.factory.DailyGoalFactory;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import com.ject.studytrip.trip.domain.model.Trip;
-import com.ject.studytrip.trip.domain.repository.DailyGoalQueryRepository;
+import com.ject.studytrip.trip.domain.repository.DailyGoalCommandRepository;
 import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DailyGoalCommandService {
     public final DailyGoalRepository dailyGoalRepository;
-    public final DailyGoalQueryRepository dailyGoalQueryRepository;
+    public final DailyGoalCommandRepository dailyGoalCommandRepository;
 
     public DailyGoal createDailyGoal(Trip trip, String title) {
         DailyGoal dailyGoal = DailyGoalFactory.create(trip, title);
@@ -25,14 +25,14 @@ public class DailyGoalCommandService {
     }
 
     public long hardDeleteDailyGoals() {
-        return dailyGoalQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return dailyGoalCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteDailyGoalsOwnedByDeletedTrip() {
-        return dailyGoalQueryRepository.deleteAllByDeletedTripOwner();
+        return dailyGoalCommandRepository.deleteAllByDeletedTripOwner();
     }
 
     public long hardDeleteDailyGoalsByMember(Long memberId) {
-        return dailyGoalQueryRepository.deleteAllByMemberId(memberId);
+        return dailyGoalCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripCommandService.java
@@ -5,7 +5,7 @@ import com.ject.studytrip.trip.domain.factory.TripFactory;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import com.ject.studytrip.trip.domain.policy.TripPolicy;
-import com.ject.studytrip.trip.domain.repository.TripQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripRepository;
 import com.ject.studytrip.trip.presentation.dto.request.CreateTripRequest;
 import com.ject.studytrip.trip.presentation.dto.request.UpdateTripRequest;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripCommandService {
     private final TripRepository tripRepository;
-    private final TripQueryRepository tripQueryRepository;
+    private final TripCommandRepository tripCommandRepository;
 
     public Trip createTrip(Member member, CreateTripRequest request) {
         TripCategory category = TripCategory.from(request.category());
@@ -70,14 +70,14 @@ public class TripCommandService {
     }
 
     public long hardDeleteTrips() {
-        return tripQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return tripCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteTripsOwnedByDeletedMember() {
-        return tripQueryRepository.deleteAllByDeletedMemberOwner();
+        return tripCommandRepository.deleteAllByDeletedMemberOwner();
     }
 
     public long hardDeleteTripsByMember(Long memberId) {
-        return tripQueryRepository.deleteAllByMemberId(memberId);
+        return tripCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
@@ -3,7 +3,7 @@ package com.ject.studytrip.trip.application.service;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.trip.domain.factory.TripReportFactory;
 import com.ject.studytrip.trip.domain.model.TripReport;
-import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripReportCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import com.ject.studytrip.trip.presentation.dto.request.CreateTripReportRequest;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripReportCommandService {
     private final TripReportRepository tripReportRepository;
-    private final TripReportQueryRepository tripReportQueryRepository;
+    private final TripReportCommandRepository tripReportCommandRepository;
 
     public TripReport createTripReport(Member member, CreateTripReportRequest request) {
         TripReport tripReport =
@@ -40,14 +40,14 @@ public class TripReportCommandService {
     }
 
     public long hardDeleteTripReports() {
-        return tripReportQueryRepository.deleteAllByDeletedAtIsNotNull();
+        return tripReportCommandRepository.deleteAllByDeletedAtIsNotNull();
     }
 
     public long hardDeleteTripReportsOwnedByDeletedMember() {
-        return tripReportQueryRepository.deleteAllByDeletedMemberOwner();
+        return tripReportCommandRepository.deleteAllByDeletedMemberOwner();
     }
 
     public long hardDeleteTripReportsByMember(Long memberId) {
-        return tripReportQueryRepository.deleteAllByMemberId(memberId);
+        return tripReportCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
@@ -4,7 +4,7 @@ import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.trip.domain.factory.TripReportStudyLogFactory;
 import com.ject.studytrip.trip.domain.model.TripReport;
 import com.ject.studytrip.trip.domain.model.TripReportStudyLog;
-import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportStudyLogRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripReportStudyLogCommandService {
     private final TripReportStudyLogRepository tripReportStudyLogRepository;
-    private final TripReportStudyLogQueryRepository tripReportStudyLogQueryRepository;
+    private final TripReportStudyLogCommandRepository tripReportStudyLogCommandRepository;
 
     public void createTripReportStudyLogs(TripReport tripReport, List<StudyLog> studyLogs) {
         List<TripReportStudyLog> tripReportStudyLogs =
@@ -26,10 +26,10 @@ public class TripReportStudyLogCommandService {
     }
 
     public long hardDeleteTripReportStudyLogsOwnedByDeletedMember() {
-        return tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner();
+        return tripReportStudyLogCommandRepository.deleteAllByDeletedMemberOwner();
     }
 
     public long hardDeleteTripReportStudyLogsByMember(Long memberId) {
-        return tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId);
+        return tripReportStudyLogCommandRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalCommandRepository.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.trip.domain.repository;
+
+public interface DailyGoalCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
+    long deleteAllByDeletedTripOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripCommandRepository.java
@@ -1,9 +1,9 @@
 package com.ject.studytrip.trip.domain.repository;
 
-public interface DailyGoalQueryRepository {
+public interface TripCommandRepository {
     long deleteAllByDeletedAtIsNotNull();
 
-    long deleteAllByDeletedTripOwner();
+    long deleteAllByDeletedMemberOwner();
 
     long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
@@ -10,10 +10,4 @@ public interface TripQueryRepository {
             Long memberId, Pageable pageable);
 
     long countActiveTripsByMemberIdAndCategory(Long memberId, TripCategory category);
-
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedMemberOwner();
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportCommandRepository.java
@@ -1,6 +1,8 @@
 package com.ject.studytrip.trip.domain.repository;
 
-public interface TripReportStudyLogQueryRepository {
+public interface TripReportCommandRepository {
+    long deleteAllByDeletedAtIsNotNull();
+
     long deleteAllByDeletedMemberOwner();
 
     long deleteAllByMemberId(Long memberId);

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
@@ -3,11 +3,5 @@ package com.ject.studytrip.trip.domain.repository;
 import java.util.List;
 
 public interface TripReportQueryRepository {
-    long deleteAllByDeletedAtIsNotNull();
-
-    long deleteAllByDeletedMemberOwner();
-
     List<String> findImageUrlsByMemberId(Long memberId);
-
-    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogCommandRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogCommandRepository.java
@@ -1,0 +1,7 @@
+package com.ject.studytrip.trip.domain.repository;
+
+public interface TripReportStudyLogCommandRepository {
+    long deleteAllByDeletedMemberOwner();
+
+    long deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/DailyGoalCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/DailyGoalCommandRepositoryAdapter.java
@@ -1,8 +1,9 @@
 package com.ject.studytrip.trip.infra.querydsl;
 
-import com.ject.studytrip.trip.domain.model.QDailyGoal;
-import com.ject.studytrip.trip.domain.model.QTrip;
-import com.ject.studytrip.trip.domain.repository.DailyGoalQueryRepository;
+import static com.ject.studytrip.trip.domain.model.QDailyGoal.dailyGoal;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.trip.domain.repository.DailyGoalCommandRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -11,10 +12,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class DailyGoalQueryRepositoryAdapter implements DailyGoalQueryRepository {
+public class DailyGoalCommandRepositoryAdapter implements DailyGoalCommandRepository {
     private final JPAQueryFactory queryFactory;
-    private final QDailyGoal dailyGoal = QDailyGoal.dailyGoal;
-    private final QTrip trip = QTrip.trip;
 
     @Override
     public long deleteAllByDeletedAtIsNotNull() {

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripCommandRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package com.ject.studytrip.trip.infra.querydsl;
+
+import static com.ject.studytrip.member.domain.model.QMember.member;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
+import com.ject.studytrip.trip.domain.repository.TripCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TripCommandRepositoryAdapter implements TripCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(trip).where(trip.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedMemberOwner() {
+        return queryFactory
+                .delete(trip)
+                .where(
+                        trip.member.id.in(
+                                JPAExpressions.select(member.id)
+                                        .from(member)
+                                        .where(member.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        return queryFactory.delete(trip).where(trip.member.id.eq(memberId)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
@@ -1,11 +1,10 @@
 package com.ject.studytrip.trip.infra.querydsl;
 
-import com.ject.studytrip.member.domain.model.QMember;
-import com.ject.studytrip.trip.domain.model.QTrip;
+import static com.ject.studytrip.trip.domain.model.QTrip.trip;
+
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
 import com.ject.studytrip.trip.domain.repository.TripQueryRepository;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -19,8 +18,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class TripQueryRepositoryAdapter implements TripQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QTrip trip = QTrip.trip;
-    private final QMember member = QMember.member;
 
     @Override
     public Slice<Trip> findSliceByMemberIdAndCompletedFalseAndDeletedAtIsNull(
@@ -58,27 +55,5 @@ public class TripQueryRepositoryAdapter implements TripQueryRepository {
                         .fetchOne();
 
         return Optional.ofNullable(count).orElse(0L);
-    }
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(trip).where(trip.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedMemberOwner() {
-        return queryFactory
-                .delete(trip)
-                .where(
-                        trip.member.id.in(
-                                JPAExpressions.select(member.id)
-                                        .from(member)
-                                        .where(member.deletedAt.isNotNull())))
-                .execute();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        return queryFactory.delete(trip).where(trip.member.id.eq(memberId)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportCommandRepositoryAdapter.java
@@ -1,0 +1,48 @@
+package com.ject.studytrip.trip.infra.querydsl;
+
+import static com.ject.studytrip.member.domain.model.QMember.member;
+import static com.ject.studytrip.trip.domain.model.QTripReport.tripReport;
+
+import com.ject.studytrip.trip.domain.repository.TripReportCommandRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TripReportCommandRepositoryAdapter implements TripReportCommandRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long deleteAllByDeletedAtIsNotNull() {
+        return queryFactory.delete(tripReport).where(tripReport.deletedAt.isNotNull()).execute();
+    }
+
+    @Override
+    public long deleteAllByDeletedMemberOwner() {
+        return queryFactory
+                .delete(tripReport)
+                .where(
+                        tripReport.member.id.in(
+                                JPAExpressions.select(member.id)
+                                        .from(member)
+                                        .where(member.deletedAt.isNotNull())))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(tripReport.id)
+                        .from(tripReport)
+                        .where(tripReport.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(tripReport).where(tripReport.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
@@ -1,9 +1,8 @@
 package com.ject.studytrip.trip.infra.querydsl;
 
-import com.ject.studytrip.member.domain.model.QMember;
-import com.ject.studytrip.trip.domain.model.QTripReport;
+import static com.ject.studytrip.trip.domain.model.QTripReport.tripReport;
+
 import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,25 +12,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class TripReportQueryRepositoryAdapter implements TripReportQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final QTripReport tripReport = QTripReport.tripReport;
-    private final QMember member = QMember.member;
-
-    @Override
-    public long deleteAllByDeletedAtIsNotNull() {
-        return queryFactory.delete(tripReport).where(tripReport.deletedAt.isNotNull()).execute();
-    }
-
-    @Override
-    public long deleteAllByDeletedMemberOwner() {
-        return queryFactory
-                .delete(tripReport)
-                .where(
-                        tripReport.member.id.in(
-                                JPAExpressions.select(member.id)
-                                        .from(member)
-                                        .where(member.deletedAt.isNotNull())))
-                .execute();
-    }
 
     @Override
     public List<String> findImageUrlsByMemberId(Long memberId) {
@@ -40,19 +20,5 @@ public class TripReportQueryRepositoryAdapter implements TripReportQueryReposito
                 .from(tripReport)
                 .where(tripReport.member.id.eq(memberId))
                 .fetch();
-    }
-
-    @Override
-    public long deleteAllByMemberId(Long memberId) {
-        List<Long> ids =
-                queryFactory
-                        .select(tripReport.id)
-                        .from(tripReport)
-                        .where(tripReport.member.id.eq(memberId))
-                        .fetch();
-
-        if (ids.isEmpty()) return 0;
-
-        return queryFactory.delete(tripReport).where(tripReport.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogCommandRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogCommandRepositoryAdapter.java
@@ -1,10 +1,11 @@
 package com.ject.studytrip.trip.infra.querydsl;
 
-import com.ject.studytrip.member.domain.model.QMember;
-import com.ject.studytrip.studylog.domain.model.QStudyLog;
-import com.ject.studytrip.trip.domain.model.QTripReport;
-import com.ject.studytrip.trip.domain.model.QTripReportStudyLog;
-import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
+import static com.ject.studytrip.member.domain.model.QMember.member;
+import static com.ject.studytrip.studylog.domain.model.QStudyLog.studyLog;
+import static com.ject.studytrip.trip.domain.model.QTripReport.tripReport;
+import static com.ject.studytrip.trip.domain.model.QTripReportStudyLog.tripReportStudyLog;
+
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogCommandRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -13,12 +14,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class TripReportStudyLogQueryRepositoryAdapter implements TripReportStudyLogQueryRepository {
+public class TripReportStudyLogCommandRepositoryAdapter
+        implements TripReportStudyLogCommandRepository {
     private final JPAQueryFactory queryFactory;
-    private final QTripReportStudyLog tripReportStudyLog = QTripReportStudyLog.tripReportStudyLog;
-    private final QTripReport tripReport = QTripReport.tripReport;
-    private final QStudyLog studyLog = QStudyLog.studyLog;
-    private final QMember member = QMember.member;
 
     @Override
     public long deleteAllByDeletedMemberOwner() {

--- a/src/test/java/com/ject/studytrip/member/application/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/member/application/service/MemberCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.ject.studytrip.member.application.dto.CreateMemberCommand;
 import com.ject.studytrip.member.domain.error.MemberErrorCode;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.domain.model.SocialProvider;
-import com.ject.studytrip.member.domain.repository.MemberQueryRepository;
+import com.ject.studytrip.member.domain.repository.MemberCommandRepository;
 import com.ject.studytrip.member.domain.repository.MemberRepository;
 import com.ject.studytrip.member.fixture.CreateMemberCommandFixture;
 import com.ject.studytrip.member.fixture.MemberFixture;
@@ -33,7 +33,7 @@ class MemberCommandServiceTest extends BaseUnitTest {
 
     @InjectMocks private MemberCommandService memberCommandService;
     @Mock private MemberRepository memberRepository;
-    @Mock private MemberQueryRepository memberQueryRepository;
+    @Mock private MemberCommandRepository memberCommandRepository;
 
     private Member member;
     private Member memberWithoutProfileImage;
@@ -256,7 +256,7 @@ class MemberCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedMembersDoNotExist() {
             // given
-            given(memberQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(memberCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = memberCommandService.hardDeleteMembers();
@@ -269,7 +269,7 @@ class MemberCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedMembersExist() {
             // given
-            given(memberQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(memberCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = memberCommandService.hardDeleteMembers();

--- a/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionCommandServiceTest.java
@@ -9,7 +9,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.mission.domain.model.DailyMission;
 import com.ject.studytrip.mission.domain.model.Mission;
-import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.DailyMissionCommandRepository;
 import com.ject.studytrip.mission.domain.repository.DailyMissionRepository;
 import com.ject.studytrip.mission.fixture.DailyMissionFixture;
 import com.ject.studytrip.mission.fixture.MissionFixture;
@@ -32,7 +32,7 @@ import org.mockito.Mock;
 class DailyMissionCommandServiceTest extends BaseUnitTest {
     @InjectMocks private DailyMissionCommandService dailyMissionCommandService;
     @Mock private DailyMissionRepository dailyMissionRepository;
-    @Mock private DailyMissionQueryRepository dailyMissionQueryRepository;
+    @Mock private DailyMissionCommandRepository dailyMissionCommandRepository;
 
     private Mission mission;
     private DailyGoal dailyGoal;
@@ -92,7 +92,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 미션이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedDailyMissionsDoNotExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissions();
@@ -105,7 +105,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 미션이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedDailyMissionsExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissions();
@@ -123,7 +123,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 미션이 소유한 데일리 미션이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDailyMissionsOwnedByDeletedMissionDoNotExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedMissionOwner()).willReturn(0L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedMissionOwner()).willReturn(0L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissionsOwnedByDeletedMission();
@@ -136,7 +136,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 미션이 소유한 데일리 미션이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDailyMissionsOwnedByDeletedMissionExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedMissionOwner()).willReturn(5L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedMissionOwner()).willReturn(5L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissionsOwnedByDeletedMission();
@@ -154,7 +154,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 데일리 미션이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDailyMissionsOwnedByDeletedDailyGoalDoNotExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
 
             // when
             long result =
@@ -168,7 +168,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 데일리 미션이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDailyMissionsOwnedByDeletedDailyGoalExist() {
             // given
-            given(dailyMissionQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
+            given(dailyMissionCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
 
             // when
             long result =
@@ -188,7 +188,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenDailyMissionsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(dailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(dailyMissionCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissionsByMember(memberId);
@@ -202,7 +202,7 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenDailyMissionsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(dailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(dailyMissionCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = dailyMissionCommandService.hardDeleteDailyMissionsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/mission/application/service/MissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/MissionCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.mission.domain.error.MissionErrorCode;
 import com.ject.studytrip.mission.domain.model.Mission;
-import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
+import com.ject.studytrip.mission.domain.repository.MissionCommandRepository;
 import com.ject.studytrip.mission.domain.repository.MissionRepository;
 import com.ject.studytrip.mission.fixture.CreateMissionRequestFixture;
 import com.ject.studytrip.mission.fixture.MissionFixture;
@@ -39,7 +39,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
 
     @InjectMocks private MissionCommandService missionCommandService;
     @Mock private MissionRepository missionRepository;
-    @Mock private MissionQueryRepository missionQueryRepository;
+    @Mock private MissionCommandRepository missionCommandRepository;
 
     private Stamp courseStamp;
     private Stamp exploreStamp;
@@ -216,7 +216,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
             // given
             Long stampId = courseStamp.getId();
             given(
-                            missionQueryRepository
+                            missionCommandRepository
                                     .existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(stampId))
                     .willReturn(true);
 
@@ -235,7 +235,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
             // given
             Long stampId = courseStamp.getId();
             given(
-                            missionQueryRepository
+                            missionCommandRepository
                                     .existsByStampIdAndCompletedIsFalseAndDeletedAtIsNull(stampId))
                     .willReturn(false);
 
@@ -253,7 +253,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 미션이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedMissionsDoNotExist() {
             // given
-            given(missionQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(missionCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = missionCommandService.hardDeleteMissions();
@@ -266,7 +266,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 미션이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedMissionsExist() {
             // given
-            given(missionQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(missionCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = missionCommandService.hardDeleteMissions();
@@ -284,7 +284,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 스탬프가 소유한 미션이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenMissionsOwnedByDeletedStampDoNotExist() {
             // given
-            given(missionQueryRepository.deleteAllByDeletedStampOwner()).willReturn(0L);
+            given(missionCommandRepository.deleteAllByDeletedStampOwner()).willReturn(0L);
 
             // when
             long result = missionCommandService.hardDeleteMissionsOwnedByDeletedStamp();
@@ -297,7 +297,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 스탬프가 소유한 미션이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenMissionsOwnedByDeletedStampExist() {
             // given
-            given(missionQueryRepository.deleteAllByDeletedStampOwner()).willReturn(5L);
+            given(missionCommandRepository.deleteAllByDeletedStampOwner()).willReturn(5L);
 
             // when
             long result = missionCommandService.hardDeleteMissionsOwnedByDeletedStamp();
@@ -316,7 +316,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenMissionsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(missionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(missionCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = missionCommandService.hardDeleteMissionsByMember(memberId);
@@ -330,7 +330,7 @@ class MissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenMissionsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(missionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(missionCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = missionCommandService.hardDeleteMissionsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandServiceTest.java
@@ -11,7 +11,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.pomodoro.domain.error.PomodoroErrorCode;
 import com.ject.studytrip.pomodoro.domain.model.Pomodoro;
-import com.ject.studytrip.pomodoro.domain.repository.PomodoroQueryRepository;
+import com.ject.studytrip.pomodoro.domain.repository.PomodoroCommandRepository;
 import com.ject.studytrip.pomodoro.domain.repository.PomodoroRepository;
 import com.ject.studytrip.pomodoro.fixture.PomodoroFixture;
 import com.ject.studytrip.pomodoro.presentation.dto.request.CreatePomodoroRequest;
@@ -31,7 +31,7 @@ import org.mockito.Mock;
 public class PomodoroCommandServiceTest extends BaseUnitTest {
     @InjectMocks private PomodoroCommandService pomodoroCommandService;
     @Mock private PomodoroRepository pomodoroRepository;
-    @Mock private PomodoroQueryRepository pomodoroQueryRepository;
+    @Mock private PomodoroCommandRepository pomodoroCommandRepository;
 
     private DailyGoal dailyGoal;
     private Pomodoro pomodoro;
@@ -124,7 +124,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 뽀모도로가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedPomodorosDoNotExist() {
             // given
-            given(pomodoroQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(pomodoroCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodoros();
@@ -137,7 +137,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 뽀모도로가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedPomodorosExist() {
             // given
-            given(pomodoroQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(pomodoroCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodoros();
@@ -155,7 +155,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 뽀모도로가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenPomodorosOwnedByDeletedDailyGoal() {
             // given
-            given(pomodoroQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
+            given(pomodoroCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodorosOwnedByDeletedDailyGoal();
@@ -168,7 +168,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 뽀모도로가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenPomodorosOwnedByDeletedDailyGoal() {
             // given
-            given(pomodoroQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
+            given(pomodoroCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodorosOwnedByDeletedDailyGoal();
@@ -187,7 +187,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenPomodorosOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(pomodoroQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(pomodoroCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodorosByMember(memberId);
@@ -201,7 +201,7 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenPomodorosOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(pomodoroQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(pomodoroCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = pomodoroCommandService.hardDeletePomodorosByMember(memberId);

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
@@ -14,7 +14,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.stamp.domain.error.StampErrorCode;
 import com.ject.studytrip.stamp.domain.model.Stamp;
-import com.ject.studytrip.stamp.domain.repository.StampQueryRepository;
+import com.ject.studytrip.stamp.domain.repository.StampCommandRepository;
 import com.ject.studytrip.stamp.domain.repository.StampRepository;
 import com.ject.studytrip.stamp.fixture.CreateStampRequestFixture;
 import com.ject.studytrip.stamp.fixture.StampFixture;
@@ -39,7 +39,7 @@ import org.mockito.Mock;
 class StampCommandServiceTest extends BaseUnitTest {
     @InjectMocks private StampCommandService stampCommandService;
     @Mock private StampRepository stampRepository;
-    @Mock private StampQueryRepository stampQueryRepository;
+    @Mock private StampCommandRepository stampCommandRepository;
 
     private Member member;
     private Trip courseTrip;
@@ -67,10 +67,12 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("스탬프 종료일이 과거 날짜라면 예외가 발생한다")
         void shouldThrowExceptionWhenEndDateIsInPast() {
             // given
+            int nextOrder = courseStamp2.getStampOrder() + 1;
             CreateStampRequest request = fixture.withEndDateInPast().build();
 
             // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamp(courseTrip, request))
+            assertThatThrownBy(
+                            () -> stampCommandService.createStamp(courseTrip, nextOrder, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(StampErrorCode.STAMP_END_DATE_CANNOT_BE_IN_PAST.getMessage());
         }
@@ -79,10 +81,12 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("스탬프 종료일이 여행 종료일보다 이후라면 예외가 발생한다")
         void shouldThrowExceptionWhenEndDateIsAfterTripEndDate() {
             // given
+            int nextOrder = courseStamp2.getStampOrder() + 1;
             CreateStampRequest request = fixture.withEndDateAfterTripEndDate().build();
 
             // when & then
-            assertThatThrownBy(() -> stampCommandService.createStamp(courseTrip, request))
+            assertThatThrownBy(
+                            () -> stampCommandService.createStamp(courseTrip, nextOrder, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(
                             StampErrorCode.STAMP_END_DATE_AFTER_TRIP_END_DATE_NOT_ALLOWED
@@ -94,51 +98,33 @@ class StampCommandServiceTest extends BaseUnitTest {
         void shouldCreateExploreStampWithOrderZero() {
             // given
             CreateStampRequest request = fixture.build();
-            // exploreTrip은 order 고정(0), save 응답 스텁
-            Stamp saved = Stamp.of(exploreTrip, request.name(), 0, request.endDate());
-            given(stampRepository.save(any())).willReturn(saved);
+            Stamp exploreStamp2 = StampFixture.createStampWithName(exploreTrip, request.name(), 0);
+            given(stampRepository.save(any(Stamp.class))).willReturn(exploreStamp2);
 
             // when
-            Stamp stamp = stampCommandService.createStamp(exploreTrip, request);
+            exploreStamp2 = stampCommandService.createStamp(exploreTrip, 0, request);
 
             // then
-            assertThat(stamp.getStampOrder()).isEqualTo(0);
+            assertThat(exploreStamp2.getTrip()).isEqualTo(exploreTrip);
+            assertThat(exploreStamp2.getName()).isEqualTo(request.name());
+            assertThat(exploreStamp2.getStampOrder()).isEqualTo(0);
         }
 
         @Test
         @DisplayName("코스형 여행에서는 마지막 order 다음 값으로 저장된다")
         void shouldCreateCourseStampWithNextSequentialOrder() {
             // given
+            int nextOrder = courseStamp2.getStampOrder() + 1;
             CreateStampRequest request = fixture.build();
-
-            // 마지막 스탬프 순서가 2라고 가정, 신규는 3으로 저장
-            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId())).willReturn(2);
-            Stamp saved = Stamp.of(courseTrip, request.name(), 3, request.endDate());
-            given(stampRepository.save(any())).willReturn(saved);
+            Stamp courseStamp3 =
+                    StampFixture.createStampWithName(courseTrip, request.name(), nextOrder);
+            given(stampRepository.save(any(Stamp.class))).willReturn(courseStamp3);
 
             // when
-            Stamp stamp = stampCommandService.createStamp(courseTrip, request);
+            courseStamp3 = stampCommandService.createStamp(courseTrip, nextOrder, request);
 
             // then
-            assertThat(stamp.getStampOrder()).isEqualTo(3);
-        }
-
-        @Test
-        @DisplayName("유효한 요청으로 스탬프를 생성하면 저장되고 반환된다")
-        void shouldCreateValidStamp() {
-            // given
-            CreateStampRequest request = fixture.build();
-            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId()))
-                    .willReturn(null);
-            Stamp saved = Stamp.of(courseTrip, request.name(), 1, request.endDate());
-            given(stampRepository.save(any())).willReturn(saved);
-
-            // when
-            Stamp stamp = stampCommandService.createStamp(courseTrip, request);
-
-            // then
-            assertThat(stamp.getName()).isEqualTo(saved.getName());
-            assertThat(stamp.getStampOrder()).isEqualTo(1);
+            assertThat(courseStamp3.getStampOrder()).isEqualTo(3);
         }
     }
 
@@ -154,7 +140,7 @@ class StampCommandServiceTest extends BaseUnitTest {
             List<CreateStampRequest> requests = List.of(fixture.build(), fixture.build());
 
             // when
-            stampCommandService.createStamps(exploreTrip, requests);
+            stampCommandService.createStamps(exploreTrip, 0, requests);
 
             // then
             verify(stampRepository).saveAll(anyList());
@@ -164,11 +150,11 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("코스형 여행에서는 마지막 order 다음 값부터 순차적으로 저장된다")
         void shouldCreateCourseStampsSequentiallyFromNextOrder() {
             // given
+            int nextOrder = courseStamp2.getStampOrder() + 1;
             List<CreateStampRequest> requests = List.of(fixture.build(), fixture.build());
-            given(stampQueryRepository.findMaxStampOrderByTripId(courseTrip.getId())).willReturn(5);
 
             // when
-            stampCommandService.createStamps(courseTrip, requests);
+            stampCommandService.createStamps(courseTrip, nextOrder, requests);
 
             // then
             verify(stampRepository).saveAll(anyList());
@@ -367,29 +353,20 @@ class StampCommandServiceTest extends BaseUnitTest {
     class DeleteStamp {
 
         @Test
-        @DisplayName("코스형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정하고, 삭제된 스탬프 이후 순서들을 하나씩 앞당긴다")
+        @DisplayName("코스형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정한다.")
         void shouldDeleteCourseTripStamp() {
-            // given
-            given(
-                            stampQueryRepository.findStampsToShiftAfterOrder(
-                                    courseTrip.getId(), courseStamp1.getStampOrder()))
-                    .willReturn(List.of(courseStamp2));
-
             // when
-            stampCommandService.deleteStamp(
-                    courseTrip.getId(), courseTrip.getCategory(), courseStamp1);
+            stampCommandService.deleteStamp(courseStamp1);
 
             // then
             assertThat(courseStamp1.getDeletedAt()).isNotNull();
-            assertThat(courseStamp2.getStampOrder()).isEqualTo(1);
         }
 
         @Test
-        @DisplayName("탐험형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정한다")
+        @DisplayName("탐험형 여행의 스탬프 삭제 시 deletedAt 필드를 현재 시각으로 설정한다.")
         void shouldDeleteExploreTripStamp() {
             // when
-            stampCommandService.deleteStamp(
-                    exploreTrip.getId(), exploreTrip.getCategory(), exploreStamp1);
+            stampCommandService.deleteStamp(exploreStamp1);
 
             // then
             assertThat(exploreStamp1.getDeletedAt()).isNotNull();
@@ -424,6 +401,31 @@ class StampCommandServiceTest extends BaseUnitTest {
     }
 
     @Nested
+    @DisplayName("shiftStampOrders 메서드는")
+    class ShiftStampOrders {
+
+        @Test
+        @DisplayName("시프트할 스탬프가 존재하지 않으면 아무 동작도 수행하지 않는다.")
+        void shouldDoNothingWhenStampsToShiftDoNotExist() {
+            // when
+            stampCommandService.shiftStampOrders(List.of());
+
+            // then
+            assertThat(courseStamp2.getStampOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("시프트할 스탬프가 존재하면 각 스탬프의 order를 1씩 감소시킨다.")
+        void shouldDecreaseOrdersByOneWhenStampsToShiftExist() {
+            // when
+            stampCommandService.shiftStampOrders(List.of(courseStamp2));
+
+            // then
+            assertThat(courseStamp2.getStampOrder()).isEqualTo(1);
+        }
+    }
+
+    @Nested
     @DisplayName("validateAllStampsCompletedByTripId 메서드는")
     class ValidateAllStampsCompletedByTripId {
 
@@ -432,7 +434,9 @@ class StampCommandServiceTest extends BaseUnitTest {
         void shouldThrowExceptionWhenAnyStampIsNotCompleted() {
             // given
             Long tripId = courseTrip.getId();
-            given(stampQueryRepository.existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId))
+            given(
+                            stampCommandRepository
+                                    .existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId))
                     .willReturn(true);
 
             // when & then
@@ -447,7 +451,9 @@ class StampCommandServiceTest extends BaseUnitTest {
         void shouldPassWhenAllStampsAreCompleted() {
             // given
             Long tripId = courseTrip.getId();
-            given(stampQueryRepository.existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId))
+            given(
+                            stampCommandRepository
+                                    .existsByTripIdAndCompletedIsFalseAndDeletedAtIsNull(tripId))
                     .willReturn(false);
 
             // when & then
@@ -464,7 +470,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 스탬프가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedStampsDoNotExist() {
             // given
-            given(stampQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(stampCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = stampCommandService.hardDeleteStamps();
@@ -477,7 +483,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 스탬프가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedStampsExist() {
             // given
-            given(stampQueryRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
+            given(stampCommandRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
 
             // when
             long result = stampCommandService.hardDeleteStampsOwnedByDeletedTrip();
@@ -495,7 +501,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 소유한 스탬프가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenStampsOwnedByDeletedTripDoNotExist() {
             // given
-            given(stampQueryRepository.deleteAllByDeletedTripOwner()).willReturn(0L);
+            given(stampCommandRepository.deleteAllByDeletedTripOwner()).willReturn(0L);
 
             // when
             long result = stampCommandService.hardDeleteStampsOwnedByDeletedTrip();
@@ -508,7 +514,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 소유한 스탬프가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenStampsOwnedByDeletedTripExist() {
             // given
-            given(stampQueryRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
+            given(stampCommandRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
 
             // when
             long result = stampCommandService.hardDeleteStampsOwnedByDeletedTrip();
@@ -585,7 +591,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenStampsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(stampQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(stampCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = stampCommandService.hardDeleteStampsByMember(memberId);
@@ -599,7 +605,7 @@ class StampCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenStampsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(stampQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(stampCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = stampCommandService.hardDeleteStampsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampQueryServiceTest.java
@@ -253,4 +253,74 @@ class StampQueryServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(stamp2.getName());
         }
     }
+
+    @Nested
+    @DisplayName("getNextStampOrderByTrip 메서드는")
+    class GetNextStampOrderByTrip {
+
+        @Test
+        @DisplayName("탐험형 여행일 경우 0을 반환한다.")
+        void shouldReturnZeroForExploreTrip() {
+            // when
+            int result = stampQueryService.getNextStampOrderByTrip(exploreTrip);
+
+            // then
+            assertThat(result).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("코스형 여행일 경우 다음 스탬프 순서를 반환한다.")
+        void shouldReturnNextStampOrderForCourseTrip() {
+            // given
+            given(stampQueryRepository.findNextStampOrderByTripId(courseTrip.getId()))
+                    .willReturn(3);
+
+            // when
+            int result = stampQueryService.getNextStampOrderByTrip(courseTrip);
+
+            // then
+            assertThat(result).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("getStampsToShiftAfterDeleted 메서드는")
+    class GetStampsToShiftAfterDeleted {
+
+        @Test
+        @DisplayName("시프트할 스탬프가 존재하지 않으면 빈 리스트를 반환한다.")
+        void shouldReturnEmptyListWhenStampsToShiftDoNotExist() {
+            // given
+            Long tripId = courseTrip.getId();
+            int deletedOrder = courseStamp2.getStampOrder();
+            given(stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedOrder))
+                    .willReturn(List.of());
+
+            // when
+            List<Stamp> result =
+                    stampQueryService.getStampsToShiftAfterDeleted(tripId, deletedOrder);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result).isEqualTo(List.of());
+        }
+
+        @Test
+        @DisplayName("시프트할 스탬프가 존재하면 스탬프 리스트를 반환한다.")
+        void shouldReturnStampsWhenStampsToShiftExist() {
+            // given
+            Long tripId = courseTrip.getId();
+            int deletedOrder = courseStamp1.getStampOrder();
+            given(stampQueryRepository.findStampsToShiftAfterOrder(tripId, deletedOrder))
+                    .willReturn(List.of(courseStamp2));
+
+            // when
+            List<Stamp> result =
+                    stampQueryService.getStampsToShiftAfterDeleted(tripId, deletedOrder);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result).isEqualTo(List.of(courseStamp2));
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
+++ b/src/test/java/com/ject/studytrip/stamp/fixture/StampFixture.java
@@ -20,4 +20,8 @@ public class StampFixture {
 
         return stamp;
     }
+
+    public static Stamp createStampWithName(Trip trip, String name, int order) {
+        return StampFactory.create(trip, name, order, DEFAULT_END_DATE);
+    }
 }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogCommandServiceTest.java
@@ -11,7 +11,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.studylog.domain.error.StudyLogErrorCode;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
-import com.ject.studytrip.studylog.domain.repository.StudyLogQueryRepository;
+import com.ject.studytrip.studylog.domain.repository.StudyLogCommandRepository;
 import com.ject.studytrip.studylog.domain.repository.StudyLogRepository;
 import com.ject.studytrip.studylog.fixture.StudyLogFixture;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
@@ -31,7 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class StudyLogCommandServiceTest extends BaseUnitTest {
     @InjectMocks private StudyLogCommandService studyLogCommandService;
     @Mock private StudyLogRepository studyLogRepository;
-    @Mock private StudyLogQueryRepository studyLogQueryRepository;
+    @Mock private StudyLogCommandRepository studyLogCommandRepository;
 
     private Member member;
     private Trip courseTrip;
@@ -81,7 +81,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 학습 로그가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedStudyLogsDoNotExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(studyLogCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogs();
@@ -94,7 +94,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 학습 로그가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedStudyLogsExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(studyLogCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogs();
@@ -112,7 +112,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 학습 로그가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenStudyLogsOwnedByDeletedMemberDoNotExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+            given(studyLogCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsOwnedByDeletedMember();
@@ -125,7 +125,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 학습 로그가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenStudyLogsOwnedByDeletedMemberExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+            given(studyLogCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsOwnedByDeletedMember();
@@ -143,7 +143,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 학습 로그가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenStudyLogsOwnedByDeletedDailyGoalDoNotExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
+            given(studyLogCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(0L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsOwnedByDeletedDailyGoal();
@@ -156,7 +156,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 소유한 학습 로그가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenStudyLogsOwnedByDeletedDailyGoalExist() {
             // given
-            given(studyLogQueryRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
+            given(studyLogCommandRepository.deleteAllByDeletedDailyGoalOwner()).willReturn(5L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsOwnedByDeletedDailyGoal();
@@ -212,7 +212,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenStudyLogsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(studyLogQueryRepository.deleteByMemberId(memberId)).willReturn(0L);
+            given(studyLogCommandRepository.deleteByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsByMember(memberId);
@@ -226,7 +226,7 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenStudyLogsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(studyLogQueryRepository.deleteByMemberId(memberId)).willReturn(5L);
+            given(studyLogCommandRepository.deleteByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = studyLogCommandService.hardDeleteStudyLogsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandServiceTest.java
@@ -15,7 +15,7 @@ import com.ject.studytrip.stamp.domain.model.Stamp;
 import com.ject.studytrip.stamp.fixture.StampFixture;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.domain.model.StudyLogDailyMission;
-import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionQueryRepository;
+import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionCommandRepository;
 import com.ject.studytrip.studylog.domain.repository.StudyLogDailyMissionRepository;
 import com.ject.studytrip.studylog.fixture.StudyLogFixture;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
@@ -35,7 +35,7 @@ import org.mockito.Mock;
 class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
     @InjectMocks private StudyLogDailyMissionCommandService studyLogDailyMissionCommandService;
     @Mock private StudyLogDailyMissionRepository studyLogDailyMissionRepository;
-    @Mock private StudyLogDailyMissionQueryRepository studyLogDailyMissionQueryRepository;
+    @Mock private StudyLogDailyMissionCommandRepository studyLogDailyMissionCommandRepository;
 
     private Member member;
     private Mission mission1;
@@ -88,7 +88,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 StudyLogDailyMission이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedStudyLogDailyMissionsDoNotExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull())
                     .willReturn(0L);
 
             // when
@@ -102,7 +102,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 StudyLogDailyMission이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedStudyLogDailyMissionsExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedAtIsNotNull())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedAtIsNotNull())
                     .willReturn(5L);
 
             // when
@@ -121,7 +121,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 미션이 소유한 StudyLogDailyMission이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenStudyLogDailyMissionsOwnedByDeletedDailyMissionDoNotExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedDailyMissionOwner())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedDailyMissionOwner())
                     .willReturn(0L);
 
             // when
@@ -137,7 +137,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 미션이 소유한 StudyLogDailyMission이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenStudyLogDailyMissionsOwnedByDeletedDailyMissionExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedDailyMissionOwner())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedDailyMissionOwner())
                     .willReturn(5L);
 
             // when
@@ -158,7 +158,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 학습 로그가 소유한 StudyLogDailyMission이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDailyMissionsOwnedByDeletedStudyLogDoNotExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedStudyLogOwner())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedStudyLogOwner())
                     .willReturn(0L);
 
             // when
@@ -174,7 +174,7 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 학습 로그가 소유한 StudyLogDailyMission이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenStudyLogDailyMissionsOwnedByDeletedStudyLogExist() {
             // given
-            given(studyLogDailyMissionQueryRepository.deleteAllByDeletedStudyLogOwner())
+            given(studyLogDailyMissionCommandRepository.deleteAllByDeletedStudyLogOwner())
                     .willReturn(5L);
 
             // when
@@ -196,7 +196,8 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenStudyLogDailyMissionsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(studyLogDailyMissionCommandRepository.deleteAllByMemberId(memberId))
+                    .willReturn(0L);
 
             // when
             long result =
@@ -212,7 +213,8 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenStudyLogDailyMissionsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(studyLogDailyMissionCommandRepository.deleteAllByMemberId(memberId))
+                    .willReturn(5L);
 
             // when
             long result =

--- a/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalCommandServiceTest.java
@@ -10,7 +10,7 @@ import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.model.DailyGoal;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
-import com.ject.studytrip.trip.domain.repository.DailyGoalQueryRepository;
+import com.ject.studytrip.trip.domain.repository.DailyGoalCommandRepository;
 import com.ject.studytrip.trip.domain.repository.DailyGoalRepository;
 import com.ject.studytrip.trip.fixture.DailyGoalFixture;
 import com.ject.studytrip.trip.fixture.TripFixture;
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 class DailyGoalCommandServiceTest extends BaseUnitTest {
     @InjectMocks private DailyGoalCommandService dailyGoalCommandService;
     @Mock private DailyGoalRepository dailyGoalRepository;
-    @Mock private DailyGoalQueryRepository dailyGoalQueryRepository;
+    @Mock private DailyGoalCommandRepository dailyGoalCommandRepository;
 
     private Trip trip;
     private DailyGoal dailyGoal;
@@ -80,7 +80,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedDailyGoalsDoNotExist() {
             // given
-            given(dailyGoalQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(dailyGoalCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoals();
@@ -93,7 +93,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 데일리 목표가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedDailyGoalsExist() {
             // given
-            given(dailyGoalQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(dailyGoalCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoals();
@@ -111,7 +111,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 소유한 데일리 목표가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDailyGoalsOwnedByDeletedTripDoNotExist() {
             // given
-            given(dailyGoalQueryRepository.deleteAllByDeletedTripOwner()).willReturn(0L);
+            given(dailyGoalCommandRepository.deleteAllByDeletedTripOwner()).willReturn(0L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoalsOwnedByDeletedTrip();
@@ -124,7 +124,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 소유한 데일리 목표가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDailyGoalsOwnedByDeletedTripExist() {
             // given
-            given(dailyGoalQueryRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
+            given(dailyGoalCommandRepository.deleteAllByDeletedTripOwner()).willReturn(5L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoalsOwnedByDeletedTrip();
@@ -143,7 +143,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenDailyGoalsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(dailyGoalQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(dailyGoalCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoalsByMember(memberId);
@@ -157,7 +157,7 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenDailyGoalsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(dailyGoalQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(dailyGoalCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = dailyGoalCommandService.hardDeleteDailyGoalsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.error.TripErrorCode;
 import com.ject.studytrip.trip.domain.model.Trip;
 import com.ject.studytrip.trip.domain.model.TripCategory;
-import com.ject.studytrip.trip.domain.repository.TripQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripRepository;
 import com.ject.studytrip.trip.fixture.CreateTripRequestFixture;
 import com.ject.studytrip.trip.fixture.TripFixture;
@@ -34,7 +34,7 @@ class TripCommandServiceTest extends BaseUnitTest {
 
     @InjectMocks private TripCommandService tripCommandService;
     @Mock private TripRepository tripRepository;
-    @Mock private TripQueryRepository tripQueryRepository;
+    @Mock private TripCommandRepository tripCommandRepository;
 
     private Member member;
     private Trip trip;
@@ -270,7 +270,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedTripsDoNotExist() {
             // given
-            given(tripQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(tripCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = tripCommandService.hardDeleteTrips();
@@ -283,7 +283,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedTripsExist() {
             // given
-            given(tripQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(tripCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = tripCommandService.hardDeleteTrips();
@@ -301,7 +301,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행이 없으면 0을 반환한다.")
         void shouldReturnZeroWhenTripsOwnedByDeletedMemberDoNotExist() {
             // given
-            given(tripQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+            given(tripCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
 
             // when
             long result = tripCommandService.hardDeleteTripsOwnedByDeletedMember();
@@ -314,7 +314,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행이 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenTripsOwnedByDeletedMemberExist() {
             // given
-            given(tripQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+            given(tripCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
 
             // when
             long result = tripCommandService.hardDeleteTripsOwnedByDeletedMember();
@@ -333,7 +333,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenTripsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(tripQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(tripCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = tripCommandService.hardDeleteTripsByMember(memberId);
@@ -347,7 +347,7 @@ class TripCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenTripsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(tripQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(tripCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = tripCommandService.hardDeleteTripsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
@@ -8,7 +8,7 @@ import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.model.TripReport;
-import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripReportCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import com.ject.studytrip.trip.fixture.CreateTripReportRequestFixture;
 import com.ject.studytrip.trip.fixture.TripReportFixture;
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 class TripReportCommandServiceTest extends BaseUnitTest {
     @InjectMocks private TripReportCommandService tripReportCommandService;
     @Mock private TripReportRepository tripReportRepository;
-    @Mock private TripReportQueryRepository tripReportQueryRepository;
+    @Mock private TripReportCommandRepository tripReportCommandRepository;
 
     private Member member;
     private TripReport tripReport;
@@ -98,7 +98,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행 리포트가 하나라도 없으면 0을 반환한다.")
         void shouldReturnZeroWhenDeletedTripReportDoesNotExist() {
             // given
-            given(tripReportQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
+            given(tripReportCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(0L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReports();
@@ -111,7 +111,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 여행 리포트가 하나라도 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenDeletedTripReportExist() {
             // given
-            given(tripReportQueryRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
+            given(tripReportCommandRepository.deleteAllByDeletedAtIsNotNull()).willReturn(5L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReports();
@@ -129,7 +129,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행 리포트가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenTripReportsOwnedByDeletedMemberDoNotExist() {
             // given
-            given(tripReportQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+            given(tripReportCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReportsOwnedByDeletedMember();
@@ -142,7 +142,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행 리포트가 있으면 해당 개수를 반환한다.")
         void shouldReturnCountWhenTripReportsOwnedByDeletedMemberExist() {
             // given
-            given(tripReportQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+            given(tripReportCommandRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReportsOwnedByDeletedMember();
@@ -161,7 +161,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenTripReportsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(tripReportQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(tripReportCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReportsByMember(memberId);
@@ -175,7 +175,7 @@ class TripReportCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenTripReportsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(tripReportQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(tripReportCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result = tripReportCommandService.hardDeleteTripReportsByMember(memberId);

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
@@ -13,7 +13,7 @@ import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.studylog.domain.model.StudyLog;
 import com.ject.studytrip.studylog.fixture.StudyLogFixture;
 import com.ject.studytrip.trip.domain.model.*;
-import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
+import com.ject.studytrip.trip.domain.repository.TripReportStudyLogCommandRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportStudyLogRepository;
 import com.ject.studytrip.trip.fixture.DailyGoalFixture;
 import com.ject.studytrip.trip.fixture.TripFixture;
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
     @InjectMocks private TripReportStudyLogCommandService tripReportStudyLogCommandService;
     @Mock private TripReportStudyLogRepository tripReportStudyLogRepository;
-    @Mock private TripReportStudyLogQueryRepository tripReportStudyLogQueryRepository;
+    @Mock private TripReportStudyLogCommandRepository tripReportStudyLogCommandRepository;
 
     private TripReport tripReport;
     private List<StudyLog> studyLogs;
@@ -72,7 +72,8 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행 리포트가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenTripReportsOwnedByDeletedMemberDoNotExist() {
             // given
-            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+            given(tripReportStudyLogCommandRepository.deleteAllByDeletedMemberOwner())
+                    .willReturn(0L);
 
             // when
             long result =
@@ -87,7 +88,8 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 학습 로그가 없으면 0을 반환한다.")
         void shouldReturnZeroWhenStudyLogsOwnedByDeletedMemberDoNotExist() {
             // given
-            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(0L);
+            given(tripReportStudyLogCommandRepository.deleteAllByDeletedMemberOwner())
+                    .willReturn(0L);
 
             // when
             long result =
@@ -102,7 +104,8 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
         @DisplayName("삭제된 멤버가 소유한 여행 리포트 또는 학습 로그가 있으면 삭제된 TripReportStudyLog 개수를 반환한다.")
         void shouldReturnCountWhenTripReportsOrStudyLogsOwnedByDeletedMemberExist() {
             // given
-            given(tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner()).willReturn(5L);
+            given(tripReportStudyLogCommandRepository.deleteAllByDeletedMemberOwner())
+                    .willReturn(5L);
 
             // when
             long result =
@@ -123,7 +126,7 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
         void shouldReturnZeroWhenTripReportStudyLogsOwnedByMemberDoNotExist() {
             // given
             Long memberId = 1L;
-            given(tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+            given(tripReportStudyLogCommandRepository.deleteAllByMemberId(memberId)).willReturn(0L);
 
             // when
             long result =
@@ -139,7 +142,7 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
         void shouldReturnCountWhenTripReportStudyLogsOwnedByMemberExist() {
             // given
             Long memberId = 1L;
-            given(tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+            given(tripReportStudyLogCommandRepository.deleteAllByMemberId(memberId)).willReturn(5L);
 
             // when
             long result =


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ CommandRepository 구현 및 명령(등록, 검증, 삭제) 로직 분리
* `MemberCommandRepository`, `MemberCommandRepositoryAdapter` 구현
* `TripCommandRepository`, `TripCommandRepositoryAdapter` 구현
* `StampCommandRepository`, `StampCommandRepositoryAdapter` 구현
* `MissionCommandRepository`, `MissionCommandRepositoryAdapter` 구현
* `DailyMissionCommandRepository`, `DailyMissionCommandRepositoryAdapter` 구현
* `StudyLogCommandRepository`, `StudyLogCommandRepositoryAdapter` 구현
* `StudyLogDailyMissionCommandRepository`, `StudyLogDailyMissionCommandRepositoryAdapter` 구현
* `PomodoroCommandRepository`, `PomodoroCommandRepositoryAdapter` 구현
* `TripReportQueryRepository`, `TripReportQueryRepositoryAdapter` 구현

### ✅ 스탬프 생성 관련 로직 개선
* `StampQueryService.getNextStampOrderByTrip()`에서 받은 **nextOrder**를 이용해 스탬프 생성 로직 개선
* `StampQueryRepository`, `StampQueryRepositoryAdapter`에서 `findMaxStampOrderByTripId` 메서드 삭제
* `StampCommandService.computeNextStampOrder()` 삭제

### ✅ 스탬프 삭제 관련 로직 개선
* `StampCommandService.deleteStamp()`에서 **스탬프 순서 변경** 로직 분리
* `StampCommandService.deleteStamp()`는 **소프트 삭제**만 담당

### ✅ QueryRepository 메서드 추가
* `StampQueryRepository`, `StampQueryRepositoryAdapter`에 `findNextStampOrderByTripId` 메서드 추가

### ✅ QueryService 메서드 추가
* `StampQueryService`에 `getNextStampOrderByTrip` 메서드 추가
* `StampQueryService`에 `getStampsToShiftAfterDeleted` 메서드 추가
* `StampCommandService`에 `shiftStampOrders` 메서드 추가

### ✅ 테스트 추가
* `StampQueryServiceTest`에 `GetNextStampOrderByTrip` 단위 테스트 추가
* `StampQueryServiceTest`에 `GetStampsToShiftAfterDeleted` 단위 테스트 추가
* `StampCommandServiceTest`에 `ShiftStampOrders` 단위 테스트 추가
* `StampFixture`에 `createStampWithName` 메서드 추가

### ✅ 테스트 수정
* `MemberCommandServiceTest` 단위 테스트 수정
* `TripCommandServiceTest` 단위 테스트 수정
* `StampCommandServiceTest` 단위 테스트 수정
* `MissionCommandServiceTest` 단위 테스트 수정
* `DailyMissionCommandServiceTest` 단위 테스트 수정
* `StudyLogCommandServiceTest` 단위 테스트 수정
* `StudyLogDailyMissionCommandServiceTest` 단위 테스트 수정
* `PomodoroCommandServiceTest` 단위 테스트 수정
* `DailyGoalCommandServiceTest` 단위 테스트 수정
* `TripReportCommandServiceTest` 단위 테스트 수정
* `TripReportStudyLogCommandServiceTest` 단위 테스트 수정

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #110 

<br/>

## 🔍 참고사항(선택)
- `QueryRepositoryAdapter`에서 Q 클래스 **static import** 적용으로 QueryDSL 가독성 향상
- `DailyGoalQueryRepository` -> `DailyGoalCommandRepository` 이름 변경
- `TripReportQueryRepository` -> `TripReportCommandRepository` 이름 변경
- `TripReportStudyLogQueryRepository` -> `TripReportStudyLogCommandRepository` 이름 변경

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-