### PR TITLE
feat: 멤버 즉시 삭제 기능 구현 (#109)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/config/S3Config.java
+++ b/src/main/java/com/ject/studytrip/global/config/S3Config.java
@@ -1,11 +1,14 @@
 package com.ject.studytrip.global.config;
 
 import com.ject.studytrip.global.config.properties.S3Properties;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -18,7 +21,21 @@ public class S3Config {
 
     @Bean
     public S3Client s3Client() {
+        RetryPolicy retry =
+                RetryPolicy.builder(RetryMode.STANDARD)
+                        .numRetries(props.retry().maxAttempts())
+                        .build();
+
         return S3Client.builder()
+                .overrideConfiguration(
+                        config ->
+                                config.retryPolicy(retry)
+                                        .apiCallTimeout(
+                                                Duration.ofSeconds(
+                                                        props.timeout().apiCallInSeconds()))
+                                        .apiCallAttemptTimeout(
+                                                Duration.ofSeconds(
+                                                        props.timeout().apiCallAttemptInSeconds())))
                 .region(Region.of(props.region()))
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/src/main/java/com/ject/studytrip/global/config/properties/S3Properties.java
+++ b/src/main/java/com/ject/studytrip/global/config/properties/S3Properties.java
@@ -3,4 +3,13 @@ package com.ject.studytrip.global.config.properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aws.s3")
-public record S3Properties(String bucket, String region, long presignExpiresInMinutes) {}
+public record S3Properties(
+        String bucket,
+        String region,
+        long presignExpiresInMinutes,
+        S3Retry retry,
+        S3Timeout timeout) {
+    public record S3Retry(int maxAttempts) {}
+
+    public record S3Timeout(int apiCallInSeconds, int apiCallAttemptInSeconds) {}
+}

--- a/src/main/java/com/ject/studytrip/image/application/dto/CleanupImagesResult.java
+++ b/src/main/java/com/ject/studytrip/image/application/dto/CleanupImagesResult.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.image.application.dto;
+
+import java.util.List;
+
+public record CleanupImagesResult(int success, List<String> failedKeys) {
+    public static CleanupImagesResult of(int success, List<String> failedKeys) {
+        return new CleanupImagesResult(success, failedKeys);
+    }
+}

--- a/src/main/java/com/ject/studytrip/image/application/event/ImageCleanupBatchEvent.java
+++ b/src/main/java/com/ject/studytrip/image/application/event/ImageCleanupBatchEvent.java
@@ -1,0 +1,9 @@
+package com.ject.studytrip.image.application.event;
+
+import java.util.List;
+
+public record ImageCleanupBatchEvent(List<String> imageUrls) {
+    public static ImageCleanupBatchEvent of(List<String> imageUrls) {
+        return new ImageCleanupBatchEvent(imageUrls);
+    }
+}

--- a/src/main/java/com/ject/studytrip/image/application/event/ImageEventListener.java
+++ b/src/main/java/com/ject/studytrip/image/application/event/ImageEventListener.java
@@ -1,0 +1,19 @@
+package com.ject.studytrip.image.application.event;
+
+import com.ject.studytrip.image.application.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+    private final ImageService imageService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCleanupBatch(ImageCleanupBatchEvent event) {
+        imageService.cleanupBatch(event.imageUrls());
+    }
+}

--- a/src/main/java/com/ject/studytrip/image/application/event/ImageEventPublisher.java
+++ b/src/main/java/com/ject/studytrip/image/application/event/ImageEventPublisher.java
@@ -1,0 +1,20 @@
+package com.ject.studytrip.image.application.event;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventPublisher {
+
+    private final ApplicationEventPublisher publisher;
+
+    public void publishCleanupBatch(List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) return;
+
+        ImageCleanupBatchEvent event = ImageCleanupBatchEvent.of(imageUrls);
+        publisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/ject/studytrip/image/application/service/ImageService.java
+++ b/src/main/java/com/ject/studytrip/image/application/service/ImageService.java
@@ -3,7 +3,9 @@ package com.ject.studytrip.image.application.service;
 import com.ject.studytrip.global.config.properties.CdnProperties;
 import com.ject.studytrip.global.exception.CustomException;
 import com.ject.studytrip.global.util.FilenameUtil;
+import com.ject.studytrip.image.application.dto.CleanupImagesResult;
 import com.ject.studytrip.image.application.dto.PresignedImageInfo;
+import com.ject.studytrip.image.application.event.ImageEventPublisher;
 import com.ject.studytrip.image.domain.constants.ImageConstants;
 import com.ject.studytrip.image.domain.factory.ImageKeyFactory;
 import com.ject.studytrip.image.domain.policy.ImagePolicy;
@@ -11,16 +13,25 @@ import com.ject.studytrip.image.domain.util.ImageUrlUtil;
 import com.ject.studytrip.image.infra.s3.dto.ImageHeadInfo;
 import com.ject.studytrip.image.infra.s3.provider.S3ImageStorageProvider;
 import com.ject.studytrip.image.infra.tika.provider.TikaImageProbeProvider;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ImageService {
+
+    private static final int MAX_BATCH = 1000;
 
     private final S3ImageStorageProvider s3Provider;
     private final TikaImageProbeProvider tikaProvider;
+
+    private final ImageEventPublisher publisher;
 
     private final CdnProperties cdnProps;
 
@@ -75,6 +86,47 @@ public class ImageService {
         ImageUrlUtil.extractKey(cdnProps.domain(), imageUrl).ifPresent(s3Provider::deleteByKey);
     }
 
+    // 이미지 배치 삭제
+    public void cleanupBatch(List<String> imageUrls) {
+        List<String> keys = extractKeysFromUrls(imageUrls);
+        if (keys.isEmpty()) return;
+
+        int attempted = 0;
+        int succeeded = 0;
+        List<String> failed = new ArrayList<>();
+
+        // 배치 삭제 (S3 DeleteObjects 최대 개수: 1000개)
+        for (int i = 0; i < keys.size(); i += MAX_BATCH) {
+            List<String> batch =
+                    new ArrayList<>(keys.subList(i, Math.min(keys.size(), i + MAX_BATCH)));
+            attempted += batch.size();
+
+            CleanupImagesResult result = s3Provider.deleteByKeys(batch);
+            succeeded += result.success();
+
+            if (!result.failedKeys().isEmpty()) failed.addAll(result.failedKeys());
+        }
+
+        log.info(
+                "Image Cleanup Batch attempted={}, succeeded={}, failed={}",
+                attempted,
+                succeeded,
+                failed.size());
+
+        if (!failed.isEmpty()) {
+            // 우선 로깅 처리
+            // 추후 Outbox 패턴으로 확장 가능
+            log.debug(
+                    "Image Cleanup Batch Failed. failedCount={}, failedKeys={}",
+                    failed.size(),
+                    failed);
+        }
+    }
+
+    public void publishCleanupBatchEvent(List<String> imageUrls) {
+        publisher.publishCleanupBatch(imageUrls);
+    }
+
     // 이미지 사이즈 검증, 실패 시 삭제
     private void validateSizeWithCleanup(String tmpKey, long contentLength) {
         try {
@@ -110,5 +162,18 @@ public class ImageService {
     private void cleanupAndThrow(String tmpKey, CustomException exception) {
         s3Provider.deleteByKey(tmpKey);
         throw exception;
+    }
+
+    // 중복, 빈 값 제거 후 키 목록 추출
+    private List<String> extractKeysFromUrls(List<String> urls) {
+        if (urls == null || urls.isEmpty()) return List.of();
+        return urls.stream()
+                .filter(Objects::nonNull)
+                .map(url -> ImageUrlUtil.extractKey(cdnProps.domain(), url))
+                .flatMap(Optional::stream)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .distinct()
+                .toList();
     }
 }

--- a/src/main/java/com/ject/studytrip/image/infra/s3/client/S3ImageStorageClient.java
+++ b/src/main/java/com/ject/studytrip/image/infra/s3/client/S3ImageStorageClient.java
@@ -56,13 +56,11 @@ public class S3ImageStorageClient {
                 () -> client.deleteObject(builder -> builder.bucket(props.bucket()).key(key)));
     }
 
-    public void deleteObjects(List<ObjectIdentifier> objects) {
-        S3ExceptionTranslator.executeWithExceptionTranslation(
-                () ->
-                        client.deleteObjects(
-                                builder ->
-                                        builder.bucket(props.bucket())
-                                                .delete(d -> d.quiet(true).objects(objects))));
+    public DeleteObjectsResponse deleteObjects(List<ObjectIdentifier> objects) {
+        return client.deleteObjects(
+                builder ->
+                        builder.bucket(props.bucket())
+                                .delete(d -> d.quiet(false).objects(objects)));
     }
 
     public void copyObject(String tmpKey, String finalKey) {

--- a/src/main/java/com/ject/studytrip/image/infra/s3/provider/S3ImageStorageProvider.java
+++ b/src/main/java/com/ject/studytrip/image/infra/s3/provider/S3ImageStorageProvider.java
@@ -1,13 +1,15 @@
 package com.ject.studytrip.image.infra.s3.provider;
 
+import com.ject.studytrip.image.application.dto.CleanupImagesResult;
 import com.ject.studytrip.image.infra.s3.client.S3ImageStorageClient;
 import com.ject.studytrip.image.infra.s3.dto.ImageHeadInfo;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @Component
@@ -35,11 +37,32 @@ public class S3ImageStorageProvider {
         s3Client.deleteObject(key);
     }
 
-    public void deleteByKeys(List<String> keys) {
+    public CleanupImagesResult deleteByKeys(List<String> keys) {
         List<ObjectIdentifier> objects =
                 keys.stream().map(key -> ObjectIdentifier.builder().key(key).build()).toList();
+        int attempts = objects.size();
 
-        s3Client.deleteObjects(objects);
+        try {
+            DeleteObjectsResponse response = s3Client.deleteObjects(objects);
+            List<String> failedKeys =
+                    response.errors() == null
+                            ? List.of()
+                            : response.errors().stream()
+                                    .map(S3Error::key)
+                                    .filter(Objects::nonNull)
+                                    .filter(key -> !key.isBlank())
+                                    .distinct()
+                                    .toList();
+            int success = attempts - failedKeys.size();
+
+            return CleanupImagesResult.of(success, failedKeys);
+        } catch (S3Exception | SdkClientException e) {
+            // S3 삭제는 멱등이기 때문에 키가 존재하지 않거나, 중복이여도 에러가 발생하지 않음
+            // 삭제 시 발생하는 에러는 보통 S3 내부 서버 문제(IO/네트워크) 혹은 인증/자격, 권한, 정책, 상태 등으로 발생
+            // 따라서 요청 레벨 실패로 간주하고 배치를 전체 실패로 처리
+            log.warn("S3 deleteObjects request failure: {}", e.getMessage(), e);
+            return CleanupImagesResult.of(0, keys);
+        }
     }
 
     public void copyByKey(String tmpKey, String finalKey) {

--- a/src/main/java/com/ject/studytrip/member/application/facade/MemberFacade.java
+++ b/src/main/java/com/ject/studytrip/member/application/facade/MemberFacade.java
@@ -13,9 +13,17 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.presentation.dto.request.ConfirmProfileImageRequest;
 import com.ject.studytrip.member.presentation.dto.request.PresignProfileImageRequest;
 import com.ject.studytrip.member.presentation.dto.request.UpdateMemberRequest;
+import com.ject.studytrip.mission.application.service.DailyMissionCommandService;
+import com.ject.studytrip.mission.application.service.MissionCommandService;
+import com.ject.studytrip.pomodoro.application.service.PomodoroCommandService;
+import com.ject.studytrip.stamp.application.service.StampCommandService;
+import com.ject.studytrip.studylog.application.service.StudyLogCommandService;
+import com.ject.studytrip.studylog.application.service.StudyLogDailyMissionCommandService;
 import com.ject.studytrip.studylog.application.service.StudyLogQueryService;
 import com.ject.studytrip.trip.application.dto.TripCount;
-import com.ject.studytrip.trip.application.service.TripQueryService;
+import com.ject.studytrip.trip.application.service.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,8 +38,19 @@ public class MemberFacade {
     private final MemberQueryService memberQueryService;
     private final TripQueryService tripQueryService;
     private final StudyLogQueryService studyLogQueryService;
+    private final TripReportQueryService tripReportQueryService;
 
     private final MemberCommandService memberCommandService;
+    private final TripCommandService tripCommandService;
+    private final StampCommandService stampCommandService;
+    private final MissionCommandService missionCommandService;
+    private final DailyGoalCommandService dailyGoalCommandService;
+    private final PomodoroCommandService pomodoroCommandService;
+    private final DailyMissionCommandService dailyMissionCommandService;
+    private final StudyLogCommandService studyLogCommandService;
+    private final StudyLogDailyMissionCommandService studyLogDailyMissionCommandService;
+    private final TripReportCommandService tripReportCommandService;
+    private final TripReportStudyLogCommandService tripReportStudyLogCommandService;
 
     private final ImageService imageService;
 
@@ -93,5 +112,52 @@ public class MemberFacade {
 
         // 새로운 이미지 업데이트
         memberCommandService.updateProfileImage(member, finalKey);
+    }
+
+    @Transactional
+    public void hardDeleteMemberCascade(Long memberId) {
+        Member member = memberQueryService.getValidMember(memberId);
+
+        // 삭제할 이미지 목록
+        List<String> imageUrls = collectImageUrlsForMember(member);
+
+        // 멤버의 모든 데이터 즉시 삭제
+        cascadeHardDeleteByMemberId(member.getId());
+
+        // 이미지 삭제 이벤트 발행
+        // 트랜잭션 커밋 이후 이미지 삭제 처리
+        imageService.publishCleanupBatchEvent(imageUrls);
+    }
+
+    private List<String> collectImageUrlsForMember(Member member) {
+        List<String> imageUrls = new ArrayList<>();
+
+        // TripReport 이미지 목록 조회
+        imageUrls.addAll(tripReportQueryService.getTripReportImageUrlsByMemberId(member.getId()));
+
+        // StudyLog 이미지 목록 조회
+        imageUrls.addAll(studyLogQueryService.getStudyLogImageUrlsByMemberId(member.getId()));
+
+        if (member.getProfileImage() != null && !member.getProfileImage().isBlank()) {
+            imageUrls.add(member.getProfileImage());
+        }
+        return imageUrls;
+    }
+
+    private void cascadeHardDeleteByMemberId(Long memberId) {
+        // 자식 -> 부모 순으로 삭제 진행
+        tripReportStudyLogCommandService.hardDeleteTripReportStudyLogsByMember(memberId);
+        tripReportCommandService.hardDeleteTripReportsByMember(memberId);
+
+        studyLogDailyMissionCommandService.hardDeleteStudyLogDailyMissionsByMember(memberId);
+        pomodoroCommandService.hardDeletePomodorosByMember(memberId);
+        studyLogCommandService.hardDeleteStudyLogsByMember(memberId);
+        dailyMissionCommandService.hardDeleteDailyMissionsByMember(memberId);
+        dailyGoalCommandService.hardDeleteDailyGoalsByMember(memberId);
+
+        missionCommandService.hardDeleteMissionsByMember(memberId);
+        stampCommandService.hardDeleteStampsByMember(memberId);
+        tripCommandService.hardDeleteTripsByMember(memberId);
+        memberCommandService.hardDeleteMemberById(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/ject/studytrip/member/application/service/MemberCommandService.java
@@ -55,6 +55,10 @@ public class MemberCommandService {
         return memberQueryRepository.deleteAllByDeletedAtIsNotNull();
     }
 
+    public void hardDeleteMemberById(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
+
     private void validateMemberIsUnique(SocialProvider socialProvider, String socialId) {
         boolean isMemberDuplicated =
                 memberRepository.existsBySocialProviderAndSocialId(socialProvider, socialId);

--- a/src/main/java/com/ject/studytrip/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/ject/studytrip/member/presentation/controller/MemberController.java
@@ -135,4 +135,13 @@ public class MemberController {
         memberFacade.confirmImage(Long.valueOf(memberId), request);
         return ResponseEntity.ok().body(StandardResponse.success(HttpStatus.OK.value(), null));
     }
+
+    @Operation(summary = "멤버 즉시 삭제", description = "멤버를 즉시 삭제하고 관련된 모든 데이터를 삭제합니다. (CASCADE)")
+    @DeleteMapping("/me/hard-delete")
+    public ResponseEntity<StandardResponse> deleteMemberHardDelete(
+            @AuthenticationPrincipal String memberId) {
+        memberFacade.hardDeleteMemberCascade(Long.valueOf(memberId));
+
+        return ResponseEntity.ok().body(StandardResponse.success(HttpStatus.OK.value(), null));
+    }
 }

--- a/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/DailyMissionCommandService.java
@@ -40,4 +40,8 @@ public class DailyMissionCommandService {
     public long hardDeleteDailyMissionsOwnedByDeletedDailyGoal() {
         return dailyMissionQueryRepository.deleteAllByDeletedDailyGoalOwner();
     }
+
+    public long hardDeleteDailyMissionsByMember(Long memberId) {
+        return dailyMissionQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionCommandService.java
@@ -59,4 +59,8 @@ public class MissionCommandService {
     public long hardDeleteMissionsOwnedByDeletedStamp() {
         return missionQueryRepository.deleteAllByDeletedStampOwner();
     }
+
+    public long hardDeleteMissionsByMember(Long memberId) {
+        return missionQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/DailyMissionQueryRepository.java
@@ -13,4 +13,6 @@ public interface DailyMissionQueryRepository {
     long deleteAllByDeletedMissionOwner();
 
     long deleteAllByDeletedDailyGoalOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/mission/domain/repository/MissionQueryRepository.java
@@ -11,4 +11,6 @@ public interface MissionQueryRepository {
     long deleteAllByDeletedAtIsNotNull();
 
     long deleteAllByDeletedStampOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/DailyMissionQueryRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.ject.studytrip.mission.domain.model.QMission;
 import com.ject.studytrip.mission.domain.repository.DailyMissionQueryRepository;
 import com.ject.studytrip.stamp.domain.model.QStamp;
 import com.ject.studytrip.trip.domain.model.QDailyGoal;
+import com.ject.studytrip.trip.domain.model.QTrip;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Repository;
 public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepository {
     private final JPAQueryFactory queryFactory;
     private final QDailyMission dailyMission = QDailyMission.dailyMission;
+    private final QTrip trip = QTrip.trip;
     private final QStamp stamp = QStamp.stamp;
     private final QMission mission = QMission.mission;
     private final QDailyGoal dailyGoal = QDailyGoal.dailyGoal;
@@ -73,5 +75,22 @@ public class DailyMissionQueryRepositoryAdapter implements DailyMissionQueryRepo
                                         .from(dailyGoal)
                                         .where(dailyGoal.deletedAt.isNotNull())))
                 .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(dailyMission.id)
+                        .from(dailyMission)
+                        .join(dailyMission.mission, mission)
+                        .join(mission.stamp, stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(dailyMission).where(dailyMission.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/mission/infra/querydsl/MissionQueryRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.ject.studytrip.mission.domain.model.Mission;
 import com.ject.studytrip.mission.domain.model.QMission;
 import com.ject.studytrip.mission.domain.repository.MissionQueryRepository;
 import com.ject.studytrip.stamp.domain.model.QStamp;
+import com.ject.studytrip.trip.domain.model.QTrip;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -16,6 +17,7 @@ public class MissionQueryRepositoryAdapter implements MissionQueryRepository {
     private final JPAQueryFactory queryFactory;
     private final QMission mission = QMission.mission;
     private final QStamp stamp = QStamp.stamp;
+    private final QTrip trip = QTrip.trip;
 
     @Override
     public List<Mission> findAllByIdsInFetchJoinStamp(List<Long> ids) {
@@ -57,5 +59,21 @@ public class MissionQueryRepositoryAdapter implements MissionQueryRepository {
                                         .from(stamp)
                                         .where(stamp.deletedAt.isNotNull())))
                 .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(mission.id)
+                        .from(mission)
+                        .join(mission.stamp, stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(mission).where(mission.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandService.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandService.java
@@ -43,4 +43,8 @@ public class PomodoroCommandService {
     public long hardDeletePomodorosOwnedByDeletedDailyGoal() {
         return pomodoroQueryRepository.deleteAllByDeletedDailyGoalOwner();
     }
+
+    public long hardDeletePomodorosByMember(Long memberId) {
+        return pomodoroQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/domain/repository/PomodoroQueryRepository.java
@@ -6,4 +6,6 @@ public interface PomodoroQueryRepository {
     long deleteAllByDeletedDailyGoalOwner();
 
     long sumFocusHoursByTripId(Long tripId);
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/pomodoro/infra/querydsl/PomodoroQueryRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.ject.studytrip.trip.domain.model.QDailyGoal;
 import com.ject.studytrip.trip.domain.model.QTrip;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -52,5 +53,21 @@ public class PomodoroQueryRepositoryAdapter implements PomodoroQueryRepository {
         long seconds = totalSeconds == null ? 0L : totalSeconds.longValue();
 
         return seconds / 3600L; // 정수 시간(내림)
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(pomodoro.id)
+                        .from(pomodoro)
+                        .join(pomodoro.dailyGoal, dailyGoal)
+                        .join(dailyGoal.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(pomodoro).where(pomodoro.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampCommandService.java
@@ -175,4 +175,8 @@ public class StampCommandService {
         Integer lastOrder = stampQueryRepository.findMaxStampOrderByTripId(tripId);
         return lastOrder == null ? 1 : lastOrder + 1;
     }
+
+    public long hardDeleteStampsByMember(Long memberId) {
+        return stampQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/stamp/domain/repository/StampQueryRepository.java
@@ -16,4 +16,6 @@ public interface StampQueryRepository {
     long deleteAllByDeletedTripOwner();
 
     Integer findMaxStampOrderByTripId(Long tripId);
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/stamp/infra/querydsl/StampQueryRepositoryAdapter.java
@@ -84,4 +84,19 @@ public class StampQueryRepositoryAdapter implements StampQueryRepository {
                 .where(stamp.trip.id.eq(tripId), stamp.deletedAt.isNull())
                 .fetchOne();
     }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(stamp.id)
+                        .from(stamp)
+                        .join(stamp.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(stamp).where(stamp.id.in(ids)).execute();
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogCommandService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogCommandService.java
@@ -39,4 +39,8 @@ public class StudyLogCommandService {
 
         studyLog.updateImageUrl(imageUrl);
     }
+
+    public long hardDeleteStudyLogsByMember(Long memberId) {
+        return studyLogQueryRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandService.java
@@ -39,4 +39,8 @@ public class StudyLogDailyMissionCommandService {
     public long hardDeleteStudyLogDailyMissionsOwnedByDeletedStudyLog() {
         return studyLogDailyMissionQueryRepository.deleteAllByDeletedStudyLogOwner();
     }
+
+    public long hardDeleteStudyLogDailyMissionsByMember(Long memberId) {
+        return studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogQueryService.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/service/StudyLogQueryService.java
@@ -60,4 +60,8 @@ public class StudyLogQueryService {
     public List<Long> getStudyLogIdsByTripId(Long tripId) {
         return studyLogQueryRepository.findAllIdsByTripIdOrderByCreatedDesc(tripId);
     }
+
+    public List<String> getStudyLogImageUrlsByMemberId(Long memberId) {
+        return studyLogQueryRepository.findImageUrlsByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogDailyMissionQueryRepository.java
@@ -13,4 +13,6 @@ public interface StudyLogDailyMissionQueryRepository {
     long deleteAllByDeletedDailyMissionOwner();
 
     long deleteAllByDeletedStudyLogOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/studylog/domain/repository/StudyLogQueryRepository.java
@@ -22,4 +22,8 @@ public interface StudyLogQueryRepository {
             Long tripReportId, Pageable pageable);
 
     List<Long> findAllIdsByTripIdOrderByCreatedDesc(Long tripId);
+
+    List<String> findImageUrlsByMemberId(Long memberId);
+
+    long deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogDailyMissionQueryRepositoryAdapter.java
@@ -71,4 +71,22 @@ public class StudyLogDailyMissionQueryRepositoryAdapter
                                         .where(studyLog.deletedAt.isNotNull())))
                 .execute();
     }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(studyLogDailyMission.id)
+                        .from(studyLogDailyMission)
+                        .join(studyLogDailyMission.studyLog, studyLog)
+                        .where(studyLog.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory
+                .delete(studyLogDailyMission)
+                .where(studyLogDailyMission.id.in(ids))
+                .execute();
+    }
 }

--- a/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/studylog/infra/querydsl/StudyLogQueryRepositoryAdapter.java
@@ -140,6 +140,20 @@ public class StudyLogQueryRepositoryAdapter implements StudyLogQueryRepository {
                 .fetch();
     }
 
+    @Override
+    public List<String> findImageUrlsByMemberId(Long memberId) {
+        return queryFactory
+                .select(studyLog.imageUrl)
+                .from(studyLog)
+                .where(studyLog.member.id.eq(memberId))
+                .fetch();
+    }
+
+    @Override
+    public long deleteByMemberId(Long memberId) {
+        return queryFactory.delete(studyLog).where(studyLog.member.id.eq(memberId)).execute();
+    }
+
     private OrderSpecifier<?>[] orderSpecifiers(String order) {
         return (order.equalsIgnoreCase("OLDEST"))
                 ? new OrderSpecifier<?>[] {studyLog.createdAt.asc(), studyLog.id.asc()}

--- a/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/DailyGoalCommandService.java
@@ -31,4 +31,8 @@ public class DailyGoalCommandService {
     public long hardDeleteDailyGoalsOwnedByDeletedTrip() {
         return dailyGoalQueryRepository.deleteAllByDeletedTripOwner();
     }
+
+    public long hardDeleteDailyGoalsByMember(Long memberId) {
+        return dailyGoalQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripCommandService.java
@@ -76,4 +76,8 @@ public class TripCommandService {
     public long hardDeleteTripsOwnedByDeletedMember() {
         return tripQueryRepository.deleteAllByDeletedMemberOwner();
     }
+
+    public long hardDeleteTripsByMember(Long memberId) {
+        return tripQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportCommandService.java
@@ -46,4 +46,8 @@ public class TripReportCommandService {
     public long hardDeleteTripReportsOwnedByDeletedMember() {
         return tripReportQueryRepository.deleteAllByDeletedMemberOwner();
     }
+
+    public long hardDeleteTripReportsByMember(Long memberId) {
+        return tripReportQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportQueryService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportQueryService.java
@@ -4,6 +4,7 @@ import com.ject.studytrip.global.exception.CustomException;
 import com.ject.studytrip.trip.domain.error.TripReportErrorCode;
 import com.ject.studytrip.trip.domain.model.TripReport;
 import com.ject.studytrip.trip.domain.policy.TripReportPolicy;
+import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TripReportQueryService {
     private final TripReportRepository tripReportRepository;
+    private final TripReportQueryRepository tripReportQueryRepository;
 
     public TripReport getTripReport(Long tripReportId) {
         return tripReportRepository
@@ -38,5 +40,9 @@ public class TripReportQueryService {
     public List<TripReport> getTripReportsByMemberId(Long memberId) {
         return tripReportRepository.findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(
                 memberId);
+    }
+
+    public List<String> getTripReportImageUrlsByMemberId(Long memberId) {
+        return tripReportQueryRepository.findImageUrlsByMemberId(memberId);
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandService.java
@@ -28,4 +28,8 @@ public class TripReportStudyLogCommandService {
     public long hardDeleteTripReportStudyLogsOwnedByDeletedMember() {
         return tripReportStudyLogQueryRepository.deleteAllByDeletedMemberOwner();
     }
+
+    public long hardDeleteTripReportStudyLogsByMember(Long memberId) {
+        return tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/DailyGoalQueryRepository.java
@@ -4,4 +4,6 @@ public interface DailyGoalQueryRepository {
     long deleteAllByDeletedAtIsNotNull();
 
     long deleteAllByDeletedTripOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripQueryRepository.java
@@ -14,4 +14,6 @@ public interface TripQueryRepository {
     long deleteAllByDeletedAtIsNotNull();
 
     long deleteAllByDeletedMemberOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportQueryRepository.java
@@ -1,7 +1,13 @@
 package com.ject.studytrip.trip.domain.repository;
 
+import java.util.List;
+
 public interface TripReportQueryRepository {
     long deleteAllByDeletedAtIsNotNull();
 
     long deleteAllByDeletedMemberOwner();
+
+    List<String> findImageUrlsByMemberId(Long memberId);
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogQueryRepository.java
+++ b/src/main/java/com/ject/studytrip/trip/domain/repository/TripReportStudyLogQueryRepository.java
@@ -2,4 +2,6 @@ package com.ject.studytrip.trip.domain.repository;
 
 public interface TripReportStudyLogQueryRepository {
     long deleteAllByDeletedMemberOwner();
+
+    long deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/DailyGoalQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/DailyGoalQueryRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.ject.studytrip.trip.domain.model.QTrip;
 import com.ject.studytrip.trip.domain.repository.DailyGoalQueryRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,5 +31,20 @@ public class DailyGoalQueryRepositoryAdapter implements DailyGoalQueryRepository
                                         .from(trip)
                                         .where(trip.deletedAt.isNotNull())))
                 .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(dailyGoal.id)
+                        .from(dailyGoal)
+                        .join(dailyGoal.trip, trip)
+                        .where(trip.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(dailyGoal).where(dailyGoal.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripQueryRepositoryAdapter.java
@@ -76,4 +76,9 @@ public class TripQueryRepositoryAdapter implements TripQueryRepository {
                                         .where(member.deletedAt.isNotNull())))
                 .execute();
     }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        return queryFactory.delete(trip).where(trip.member.id.eq(memberId)).execute();
+    }
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportQueryRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.ject.studytrip.trip.domain.model.QTripReport;
 import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,5 +31,28 @@ public class TripReportQueryRepositoryAdapter implements TripReportQueryReposito
                                         .from(member)
                                         .where(member.deletedAt.isNotNull())))
                 .execute();
+    }
+
+    @Override
+    public List<String> findImageUrlsByMemberId(Long memberId) {
+        return queryFactory
+                .select(tripReport.imageUrl)
+                .from(tripReport)
+                .where(tripReport.member.id.eq(memberId))
+                .fetch();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(tripReport.id)
+                        .from(tripReport)
+                        .where(tripReport.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory.delete(tripReport).where(tripReport.id.in(ids)).execute();
     }
 }

--- a/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogQueryRepositoryAdapter.java
+++ b/src/main/java/com/ject/studytrip/trip/infra/querydsl/TripReportStudyLogQueryRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.ject.studytrip.trip.domain.model.QTripReportStudyLog;
 import com.ject.studytrip.trip.domain.repository.TripReportStudyLogQueryRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -38,6 +39,24 @@ public class TripReportStudyLogQueryRepositoryAdapter implements TripReportStudy
                                                         .from(studyLog)
                                                         .join(studyLog.member, member)
                                                         .where(member.deletedAt.isNotNull()))))
+                .execute();
+    }
+
+    @Override
+    public long deleteAllByMemberId(Long memberId) {
+        List<Long> ids =
+                queryFactory
+                        .select(tripReportStudyLog.id)
+                        .from(tripReportStudyLog)
+                        .join(tripReportStudyLog.tripReport, tripReport)
+                        .where(tripReport.member.id.eq(memberId))
+                        .fetch();
+
+        if (ids.isEmpty()) return 0;
+
+        return queryFactory
+                .delete(tripReportStudyLog)
+                .where(tripReportStudyLog.id.in(ids))
                 .execute();
     }
 }

--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -8,3 +8,8 @@ aws:
     bucket: ${S3_BUCKET_NAME:}
     region: ${AWS_REGION:}
     presign-expires-in-minutes: ${PRESIGN_EXPIRES_IN_MINUTES:10}
+    retry:
+      max-attempts: ${AWS_S3_MAX_ATTEMPTS:5}
+    timeout:
+      api-call-in-seconds: ${AWS_S3_API_CALL_TIMEOUT:10}
+      api-call-attempt-in-seconds: ${AWS_S3_API_CALL_ATTEMPT_TIMEOUT:5}

--- a/src/test/java/com/ject/studytrip/image/application/service/ImageServiceTest.java
+++ b/src/test/java/com/ject/studytrip/image/application/service/ImageServiceTest.java
@@ -3,21 +3,26 @@ package com.ject.studytrip.image.application.service;
 import static com.ject.studytrip.image.fixture.ImageTestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.global.config.properties.CdnProperties;
 import com.ject.studytrip.global.exception.CustomException;
+import com.ject.studytrip.image.application.dto.CleanupImagesResult;
 import com.ject.studytrip.image.application.dto.PresignedImageInfo;
+import com.ject.studytrip.image.application.event.ImageEventPublisher;
 import com.ject.studytrip.image.domain.error.ImageErrorCode;
 import com.ject.studytrip.image.fixture.ImageHeadInfoFixture;
 import com.ject.studytrip.image.infra.s3.dto.ImageHeadInfo;
 import com.ject.studytrip.image.infra.s3.error.S3ErrorCode;
 import com.ject.studytrip.image.infra.s3.provider.S3ImageStorageProvider;
 import com.ject.studytrip.image.infra.tika.provider.TikaImageProbeProvider;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +38,7 @@ class ImageServiceTest extends BaseUnitTest {
     @Mock private S3ImageStorageProvider s3Provider;
     @Mock private TikaImageProbeProvider tikaProvider;
     @Mock private CdnProperties cdnProperties;
+    @Mock private ImageEventPublisher imageEventPublisher;
 
     @Nested
     @DisplayName("presign 메서드는")
@@ -342,6 +348,185 @@ class ImageServiceTest extends BaseUnitTest {
 
             // then
             verify(s3Provider, never()).deleteByKey(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupBatch 메서드는")
+    class CleanupBatch {
+        private static final String IMAGE_BASE_URL = "https://test-cdn.cloudfront.net";
+        private static final String VALID_IMAGE_URL1 = IMAGE_BASE_URL + "/members/1/image1.jpg";
+        private static final String VALID_IMAGE_URL2 = IMAGE_BASE_URL + "/members/1/image2.jpg";
+        private static final String VALID_KEY1 = "members/1/image1.jpg";
+        private static final String VALID_KEY2 = "members/1/image2.jpg";
+
+        @Test
+        @DisplayName("빈 리스트로 호출하면 아무 작업도 수행하지 않는다")
+        void shouldDoNothingWhenListIsEmpty() {
+            // when
+            imageService.cleanupBatch(List.of());
+
+            // then
+            verify(s3Provider, never()).deleteByKeys(any());
+        }
+
+        @Test
+        @DisplayName("null 리스트로 호출하면 아무 작업도 수행하지 않는다")
+        void shouldDoNothingWhenListIsNull() {
+            // when
+            imageService.cleanupBatch(null);
+
+            // then
+            verify(s3Provider, never()).deleteByKeys(any());
+        }
+
+        @Test
+        @DisplayName("유효한 이미지 URL 리스트로 배치 삭제를 수행한다")
+        void shouldDeleteImagesBatchWhenValidUrls() {
+            // given
+            List<String> imageUrls = Arrays.asList(VALID_IMAGE_URL1, VALID_IMAGE_URL2);
+            List<String> keys = Arrays.asList(VALID_KEY1, VALID_KEY2);
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(keys)).willReturn(CleanupImagesResult.of(2, List.of()));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider).deleteByKeys(keys);
+        }
+
+        @Test
+        @DisplayName("일부 이미지 삭제 실패 시 실패한 키를 수집한다")
+        void shouldCollectFailedKeysWhenSomeDeletionsFail() {
+            // given
+            List<String> imageUrls = Arrays.asList(VALID_IMAGE_URL1, VALID_IMAGE_URL2);
+            List<String> keys = Arrays.asList(VALID_KEY1, VALID_KEY2);
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(keys))
+                    .willReturn(CleanupImagesResult.of(1, Arrays.asList(VALID_KEY2)));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider).deleteByKeys(keys);
+        }
+
+        @Test
+        @DisplayName("1000개 이상의 이미지 URL이 들어오면 배치로 나누어 처리한다")
+        void shouldSplitBatchWhenUrlsExceedMaxBatch() {
+            // given
+            List<String> imageUrls = new ArrayList<>();
+            List<String> keys = new ArrayList<>();
+            for (int i = 0; i < 1500; i++) {
+                String url = IMAGE_BASE_URL + "/members/1/image" + i + ".jpg";
+                String key = "members/1/image" + i + ".jpg";
+                imageUrls.add(url);
+                keys.add(key);
+            }
+
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(any()))
+                    .willReturn(CleanupImagesResult.of(1000, List.of()));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider, atLeast(2)).deleteByKeys(any());
+        }
+
+        @Test
+        @DisplayName("null URL이 포함된 리스트는 필터링하여 처리한다")
+        void shouldFilterNullUrls() {
+            // given
+            List<String> imageUrls =
+                    Arrays.asList(VALID_IMAGE_URL1, null, VALID_IMAGE_URL2, "", "invalid-url");
+            List<String> keys = Arrays.asList(VALID_KEY1, VALID_KEY2);
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(keys)).willReturn(CleanupImagesResult.of(2, List.of()));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider).deleteByKeys(keys);
+        }
+
+        @Test
+        @DisplayName("중복된 이미지 URL은 한 번만 처리한다")
+        void shouldRemoveDuplicateUrls() {
+            // given
+            List<String> imageUrls =
+                    Arrays.asList(VALID_IMAGE_URL1, VALID_IMAGE_URL1, VALID_IMAGE_URL2);
+            List<String> keys = Arrays.asList(VALID_KEY1, VALID_KEY2);
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(keys)).willReturn(CleanupImagesResult.of(2, List.of()));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider).deleteByKeys(keys);
+        }
+
+        @Test
+        @DisplayName("잘못된 CDN 도메인을 가진 URL은 필터링하여 처리한다")
+        void shouldFilterInvalidCdnDomainUrls() {
+            // given
+            String wrongDomainUrl = "https://wrong-cdn.com/members/1/image1.jpg";
+            List<String> imageUrls = Arrays.asList(VALID_IMAGE_URL1, wrongDomainUrl);
+            List<String> keys = Arrays.asList(VALID_KEY1);
+            given(cdnProperties.domain()).willReturn(IMAGE_BASE_URL);
+            given(s3Provider.deleteByKeys(keys)).willReturn(CleanupImagesResult.of(1, List.of()));
+
+            // when
+            imageService.cleanupBatch(imageUrls);
+
+            // then
+            verify(s3Provider).deleteByKeys(keys);
+        }
+    }
+
+    @Nested
+    @DisplayName("publishCleanupBatchEvent 메서드는")
+    class PublishCleanupBatchEvent {
+
+        @Test
+        @DisplayName("유효한 이미지 URL 리스트로 이벤트를 발행한다")
+        void shouldPublishEventWhenImageUrlsAreValid() {
+            // given
+            List<String> imageUrls =
+                    Arrays.asList(
+                            "https://cdn.example.com/members/1/image1.jpg",
+                            "https://cdn.example.com/members/1/image2.jpg");
+
+            // when
+            imageService.publishCleanupBatchEvent(imageUrls);
+
+            // then
+            verify(imageEventPublisher).publishCleanupBatch(imageUrls);
+        }
+
+        @Test
+        @DisplayName("빈 리스트로 호출하면 이벤트는 발행되지만 내부에서 처리되지 않는다.")
+        void shouldNotPublishEventWhenListIsEmpty() {
+            // when
+            imageService.publishCleanupBatchEvent(List.of());
+
+            // then
+            verify(imageEventPublisher).publishCleanupBatch(List.of());
+        }
+
+        @Test
+        @DisplayName("null 리스트로 호출하면 이벤트는 발행되지만 내부에서 처리되지 않는다.")
+        void shouldNotPublishEventWhenListIsNull() {
+            // when
+            imageService.publishCleanupBatchEvent(null);
+
+            // then
+            verify(imageEventPublisher).publishCleanupBatch(null);
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/member/application/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/member/application/service/MemberCommandServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.ject.studytrip.BaseUnitTest;
 import com.ject.studytrip.global.exception.CustomException;
@@ -275,6 +276,24 @@ class MemberCommandServiceTest extends BaseUnitTest {
 
             // then
             assertThat(result).isEqualTo(5L);
+        }
+    }
+
+    @Nested
+    @DisplayName("hardDeleteMemberById 메서드는")
+    class HardDeleteMemberById {
+
+        @Test
+        @DisplayName("전달된 멤버 ID로 삭제를 수행한다")
+        void shouldDeleteById() {
+            // given
+            Long memberId = 123L;
+
+            // when
+            memberCommandService.hardDeleteMemberById(memberId);
+
+            // then
+            verify(memberRepository).deleteById(memberId);
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/member/presentation/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/ject/studytrip/member/presentation/controller/MemberControllerIntegrationTest.java
@@ -459,4 +459,69 @@ class MemberControllerIntegrationTest extends BaseIntegrationTest {
             resultActions.andExpect(status().isBadRequest());
         }
     }
+
+    @Nested
+    @DisplayName("멤버 즉시 삭제 API")
+    class DeleteMemberHardDelete {
+        private ResultActions getResultActions(String accessToken) throws Exception {
+            return mockMvc.perform(
+                    delete(BASE_MEMBER_URL + "/me/hard-delete")
+                            .header(
+                                    HttpHeaders.AUTHORIZATION,
+                                    TokenFixture.TOKEN_PREFIX + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON));
+        }
+
+        @Test
+        @DisplayName("Access Token이 없으면 401 Unauthorized를 반환한다.")
+        void shouldReturnUnauthorizedWhenAccessTokenIsMissing() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions("");
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getStatus().value()))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(AuthErrorCode.UNAUTHENTICATED.getMessage()));
+        }
+
+        @Test
+        @DisplayName("삭제된 멤버일 경우 404 Not Found를 반환한다.")
+        void shouldReturnNotFoundWhenMemberAlreadyDeleted() throws Exception {
+            // given
+            member.updateDeletedAt();
+
+            // when
+            ResultActions resultActions = getResultActions(accessToken);
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(
+                            jsonPath("$.status")
+                                    .value(MemberErrorCode.MEMBER_NOT_FOUND.getStatus().value()))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("유효한 멤버 ID가 들어오면 멤버와 관련된 모든 데이터를 즉시 삭제한다.")
+        void shouldHardDeleteMemberAndAllRelatedDataWhenMemberIdIsValid() throws Exception {
+            // when
+            ResultActions resultActions = getResultActions(accessToken);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()));
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/DailyMissionCommandServiceTest.java
@@ -178,4 +178,37 @@ class DailyMissionCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteDailyMissionsByMember 메서드는")
+    class HardDeleteDailyMissionsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 데일리 미션이 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenDailyMissionsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(dailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = dailyMissionCommandService.hardDeleteDailyMissionsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 데일리 미션이 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenDailyMissionsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(dailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = dailyMissionCommandService.hardDeleteDailyMissionsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/mission/application/service/MissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/MissionCommandServiceTest.java
@@ -306,4 +306,37 @@ class MissionCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteMissionsByMember 메서드는")
+    class HardDeleteMissionsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 미션이 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenMissionsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(missionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = missionCommandService.hardDeleteMissionsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 미션이 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenMissionsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(missionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = missionCommandService.hardDeleteMissionsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/pomodoro/application/service/PomodoroCommandServiceTest.java
@@ -177,4 +177,37 @@ public class PomodoroCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeletePomodorosByMember 메서드는")
+    class HardDeletePomodorosByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 뽀모도로가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenPomodorosOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(pomodoroQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = pomodoroCommandService.hardDeletePomodorosByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 뽀모도로가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenPomodorosOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(pomodoroQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = pomodoroCommandService.hardDeletePomodorosByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampCommandServiceTest.java
@@ -575,4 +575,37 @@ class StampCommandServiceTest extends BaseUnitTest {
                     .isEqualTo(initialCompletedMissions + increaseCount);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteStampsByMember 메서드는")
+    class HardDeleteStampsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 스탬프가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenStampsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(stampQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = stampCommandService.hardDeleteStampsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 스탬프가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenStampsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(stampQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = stampCommandService.hardDeleteStampsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogCommandServiceTest.java
@@ -202,4 +202,37 @@ class StudyLogCommandServiceTest extends BaseUnitTest {
             assertThat(studyLog.getImageUrl()).isNotEqualTo(oldImageUrl);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteStudyLogsByMember 메서드는")
+    class HardDeleteStudyLogsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 학습 로그가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenStudyLogsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(studyLogQueryRepository.deleteByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = studyLogCommandService.hardDeleteStudyLogsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 학습 로그가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenStudyLogsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(studyLogQueryRepository.deleteByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = studyLogCommandService.hardDeleteStudyLogsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogDailyMissionCommandServiceTest.java
@@ -186,4 +186,41 @@ class StudyLogDailyMissionCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteStudyLogDailyMissionsByMember 메서드는")
+    class HardDeleteStudyLogDailyMissionsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 학습 로그 데일리 미션이 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenStudyLogDailyMissionsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result =
+                    studyLogDailyMissionCommandService.hardDeleteStudyLogDailyMissionsByMember(
+                            memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 학습 로그 데일리 미션이 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenStudyLogDailyMissionsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(studyLogDailyMissionQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result =
+                    studyLogDailyMissionCommandService.hardDeleteStudyLogDailyMissionsByMember(
+                            memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/studylog/application/service/StudyLogQueryServiceTest.java
@@ -319,4 +319,42 @@ class StudyLogQueryServiceTest extends BaseUnitTest {
             assertThat(result.get(1)).isEqualTo(studyLogId2);
         }
     }
+
+    @Nested
+    @DisplayName("getStudyLogImageUrlsByMemberId 메서드는")
+    class GetStudyLogImageUrlsByMemberId {
+
+        @Test
+        @DisplayName("이미지가 없으면 빈 리스트를 반환한다")
+        void shouldReturnEmptyListWhenNoImages() {
+            // given
+            Long memberId = member.getId();
+            given(studyLogQueryRepository.findImageUrlsByMemberId(memberId)).willReturn(List.of());
+
+            // when
+            List<String> result = studyLogQueryService.getStudyLogImageUrlsByMemberId(memberId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이미지가 존재하면 URL 리스트를 반환한다")
+        void shouldReturnImageUrlsWhenExist() {
+            // given
+            Long memberId = member.getId();
+            List<String> imageUrls =
+                    List.of(
+                            "https://cdn.example.com/studylogs/1.jpg",
+                            "https://cdn.example.com/studylogs/2.jpg");
+            given(studyLogQueryRepository.findImageUrlsByMemberId(memberId)).willReturn(imageUrls);
+
+            // when
+            List<String> result = studyLogQueryService.getStudyLogImageUrlsByMemberId(memberId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).isEqualTo(imageUrls);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/DailyGoalCommandServiceTest.java
@@ -133,4 +133,37 @@ class DailyGoalCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteDailyGoalsByMember 메서드는")
+    class HardDeleteDailyGoalsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 데일리 목표가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenDailyGoalsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(dailyGoalQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = dailyGoalCommandService.hardDeleteDailyGoalsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 데일리 목표가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenDailyGoalsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(dailyGoalQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = dailyGoalCommandService.hardDeleteDailyGoalsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripCommandServiceTest.java
@@ -323,4 +323,37 @@ class TripCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteTripsByMember 메서드는")
+    class HardDeleteTripsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행이 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenTripsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(tripQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = tripCommandService.hardDeleteTripsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행이 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenTripsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(tripQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = tripCommandService.hardDeleteTripsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportCommandServiceTest.java
@@ -151,4 +151,37 @@ class TripReportCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteTripReportsByMember 메서드는")
+    class HardDeleteTripReportsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행 리포트가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenTripReportsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(tripReportQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result = tripReportCommandService.hardDeleteTripReportsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행 리포트가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenTripReportsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(tripReportQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result = tripReportCommandService.hardDeleteTripReportsByMember(memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportQueryServiceTest.java
@@ -10,6 +10,7 @@ import com.ject.studytrip.member.domain.model.Member;
 import com.ject.studytrip.member.fixture.MemberFixture;
 import com.ject.studytrip.trip.domain.error.TripReportErrorCode;
 import com.ject.studytrip.trip.domain.model.TripReport;
+import com.ject.studytrip.trip.domain.repository.TripReportQueryRepository;
 import com.ject.studytrip.trip.domain.repository.TripReportRepository;
 import com.ject.studytrip.trip.fixture.TripReportFixture;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.mockito.Mock;
 class TripReportQueryServiceTest extends BaseUnitTest {
     @InjectMocks private TripReportQueryService tripReportQueryService;
     @Mock private TripReportRepository tripReportRepository;
+    @Mock private TripReportQueryRepository tripReportQueryRepository;
 
     private Member member;
     private TripReport tripReport1;
@@ -188,6 +190,46 @@ class TripReportQueryServiceTest extends BaseUnitTest {
             assertThat(result.size()).isEqualTo(2);
             assertThat(result.get(0).getId()).isEqualTo(tripReport1.getId());
             assertThat(result.get(1).getId()).isEqualTo(tripReport2.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("getTripReportImageUrlsByMemberId 메서드는")
+    class GetTripReportImageUrlsByMemberId {
+
+        @Test
+        @DisplayName("이미지가 없으면 빈 리스트를 반환한다")
+        void shouldReturnEmptyListWhenNoImages() {
+            // given
+            Long memberId = member.getId();
+            given(tripReportQueryRepository.findImageUrlsByMemberId(memberId))
+                    .willReturn(List.of());
+
+            // when
+            List<String> result = tripReportQueryService.getTripReportImageUrlsByMemberId(memberId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이미지가 존재하면 URL 리스트를 반환한다")
+        void shouldReturnImageUrlsWhenExist() {
+            // given
+            Long memberId = member.getId();
+            List<String> imageUrls =
+                    List.of(
+                            "https://cdn.example.com/reports/1.jpg",
+                            "https://cdn.example.com/reports/2.jpg");
+            given(tripReportQueryRepository.findImageUrlsByMemberId(memberId))
+                    .willReturn(imageUrls);
+
+            // when
+            List<String> result = tripReportQueryService.getTripReportImageUrlsByMemberId(memberId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).isEqualTo(imageUrls);
         }
     }
 }

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripReportStudyLogCommandServiceTest.java
@@ -113,4 +113,41 @@ class TripReportStudyLogCommandServiceTest extends BaseUnitTest {
             assertThat(result).isEqualTo(5L);
         }
     }
+
+    @Nested
+    @DisplayName("hardDeleteTripReportStudyLogsByMember 메서드는")
+    class HardDeleteTripReportStudyLogsByMember {
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행 리포트 학습 로그가 없으면 0을 반환한다.")
+        void shouldReturnZeroWhenTripReportStudyLogsOwnedByMemberDoNotExist() {
+            // given
+            Long memberId = 1L;
+            given(tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId)).willReturn(0L);
+
+            // when
+            long result =
+                    tripReportStudyLogCommandService.hardDeleteTripReportStudyLogsByMember(
+                            memberId);
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("특정 멤버가 소유한 여행 리포트 학습 로그가 있으면 해당 개수를 반환한다.")
+        void shouldReturnCountWhenTripReportStudyLogsOwnedByMemberExist() {
+            // given
+            Long memberId = 1L;
+            given(tripReportStudyLogQueryRepository.deleteAllByMemberId(memberId)).willReturn(5L);
+
+            // when
+            long result =
+                    tripReportStudyLogCommandService.hardDeleteTripReportStudyLogsByMember(
+                            memberId);
+
+            // then
+            assertThat(result).isEqualTo(5L);
+        }
+    }
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
- 서비스에서 데이터 삭제 과정이 `논리 삭제 -> 물리 삭제` 흐름으로 진행되는데, 테스트 편리성을 위해 API 요청 즉시 물리 삭제 처리되도록 기능을 구현했습니다.

### ✅ S3 스토리지 retry, time-out 설정 추가
- 이미지 관련 작업 중 예기치 못한 IO/네트워크 오류 등으로 재시도가 필요한 상황이 생길 수도 있어 `Retry(재시도)`를 설정했습니다.
- S3 네트워크 지연이나 응답이 정체되는 상황에서 무한 대기에 빠지지 않고 시스템의 안정성을 높이기 위해 `time-out(타임아웃)`을 설정했습니다.
- `application-storage.yml` 파일에 S3 `retry`, `time-out` 설정을 추가했습니다.
- `S3Config`에서 `S3Client` 빈을 등록하는 부분에 `retry`, `time-out` 옵션을 설정했습니다.
- `Retry(재시도)`는 코드 상으로 직접 구현하거나 `Spring Retry` 같은 라이브러리를 활용할 수도 있지만, 코드가 더 복잡해지고 학습하는 데 시간이 걸릴 것 같아 `AWS SDK V2`가 기본으로 제공하는 재시도와 타임아웃 설정 옵션을 사용했습니다.

<br/>

### ✅ 멤버 즉시 삭제 기능 구현 (CASCADE)
- 로그인된 회원의 ID를 기반으로 관련된 모든 데이터를 삭제하는 기능을 추가했습니다.
- 자식 데이터부터 순차적으로 삭제하고, 마지막에 제일 최상위 데이터인 멤버 모델이 삭제되도록 구현했습니다.
- `Member`, `StudyLog`, `TripReport`는 이미지를 보유하고 있는데, 관련된 실제 이미지를 함께 삭제하기 위해 `트랜잭션 기반 이벤트 처리(Transactional Event)` 방식을 사용했습니다.

<br/>

### ✅ 이벤트 기반 이미지 배치 정리 기능 추가
- 이벤트를 활용하면서 엔티티 삭제와 이미지 정리 로직을 분리하고, 트랜잭션이 성공적으로 커밋된 이후에만 실제 이미지 삭제가 수행되도록 보장했습니다.
- 트랜잭션 기반 이벤트 처리를 적용하지 않고, 하나의 트랜잭션 내에서 엔티티 삭제와 이미지 정리 로직을 함께 수행할 경우 문제가 발생할 수 있습니다.
일부 이미지가 삭제된 시점에서 에러가 발생하면, 데이터베이스 변경사항은 모두 롤백되지만 S3와 같은 외부 스토리지는 이미 처리된 작업에 대한 롤백이 불가능하기 때문에 DB 데이터와 실제 스토리지 상태 간의 정합성이 불일치하는 문제가 발생할 수 있습니다.
이를 방지하고 안정성을 높이고자 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`를 사용했습니다.
- 이벤트 발행은 멤버 도메인에서 처리할 수도 있지만, `이벤트 발행/이벤트 정의/구독`을 모두 `image.application` 계층에 배치했습니다.
이미지 정리 로직이 멤버 도메인, 멤버 삭제와 같은 행위에 종속되지 않고 **이미지 정리**를 중심으로 동작하기 위해서 `image` 모듈에 정의했습니다. 추후 다른 곳에서 이미지 정리 이벤트가 필요할 경우 재사용하거나 커스텀해서 사용할 수 있을 것 같습니다.

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #109 

<br/>

## 🔍 참고사항(선택)

- `ImageService.cleanupBatch()`에서 이미지 정리에 실패한 항목을 따로 저장하거나 바로 재시도하지 않고 단순히 로그만 남기도록 구현했습니다.
이 기능이 핵심 기능이 아니라 효율적이고 빠른 테스트를 위한 보조 기능이라 이렇게 설계했는데, 추후 확장할 수도 있을 것 같습니다.
찾아 보니 `failed_deleted_image` 같은 테이블을 별도로 두고 스케줄러를 기반으로 재시도하는 방법을 적용할 수도 있고,
Outbox 패턴을 적용해 실패한 삭제 작업을 비동기로 처리하는 방식을 적용할 수도 있고,
메트릭 수집 및 모니터링 시스템을 도입해 이미지 정리 성공률과 실패율을 추적하는 방향으로도 발전시킬 수 있다고 합니다.
참고하면 좋을 것 같습니다!
<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-