### PR TITLE
refactor: 여행, 스탬프, 미션 조회 비즈니스 로직에 완료 여부 검증 정책 추가(#116)

### DIFF
--- a/src/main/java/com/ject/studytrip/member/application/facade/MemberFacade.java
+++ b/src/main/java/com/ject/studytrip/member/application/facade/MemberFacade.java
@@ -102,6 +102,9 @@ public class MemberFacade {
         return PresignedProfileImageInfo.of(member.getId(), info.tmpKey(), info.presignedUrl());
     }
 
+    @CacheEvict(
+            cacheNames = MEMBER,
+            key = "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).member(#memberId)")
     @Transactional
     public void confirmImage(Long memberId, ConfirmProfileImageRequest request) {
         Member member = memberQueryService.getValidMember(memberId);

--- a/src/main/java/com/ject/studytrip/mission/application/service/MissionQueryService.java
+++ b/src/main/java/com/ject/studytrip/mission/application/service/MissionQueryService.java
@@ -24,6 +24,7 @@ public class MissionQueryService {
 
         MissionPolicy.validateMissionBelongsToStamp(stampId, mission);
         MissionPolicy.validateNotDeleted(mission);
+        MissionPolicy.validateCompleted(mission);
 
         return mission;
     }

--- a/src/main/java/com/ject/studytrip/stamp/application/service/StampQueryService.java
+++ b/src/main/java/com/ject/studytrip/stamp/application/service/StampQueryService.java
@@ -30,6 +30,7 @@ public class StampQueryService {
 
         StampPolicy.validateStampBelongsToTrip(tripId, stamp);
         StampPolicy.validateNotDeleted(stamp);
+        StampPolicy.validateCompleted(stamp);
 
         return stamp;
     }

--- a/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
+++ b/src/main/java/com/ject/studytrip/studylog/application/facade/StudyLogFacade.java
@@ -119,6 +119,7 @@ public class StudyLogFacade {
         return PresignedStudyLogImageInfo.of(studyLog.getId(), info.tmpKey(), info.presignedUrl());
     }
 
+    @CacheEvict(cacheNames = STUDY_LOGS, allEntries = true)
     @Transactional
     public void confirmImage(Long studyLogId, ConfirmStudyLogImageRequest request) {
         StudyLog studyLog = studyLogQueryService.getValidStudyLog(studyLogId);

--- a/src/main/java/com/ject/studytrip/trip/application/service/TripQueryService.java
+++ b/src/main/java/com/ject/studytrip/trip/application/service/TripQueryService.java
@@ -33,6 +33,7 @@ public class TripQueryService {
 
         TripPolicy.validateOwner(memberId, trip);
         TripPolicy.validateNotDeleted(trip);
+        TripPolicy.validateCompleted(trip);
 
         return trip;
     }

--- a/src/test/java/com/ject/studytrip/mission/application/service/MissionQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/mission/application/service/MissionQueryServiceTest.java
@@ -100,6 +100,21 @@ class MissionQueryServiceTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("미션이 이미 완료된 경우 예외가 발생한다.")
+        void shouldThrowExceptionWhenMissionIsCompleted() {
+            // given
+            exploreMission1.updateCompleted();
+            Long stampId = exploreStamp.getId();
+            Long missionId = exploreMission1.getId();
+            given(missionRepository.findById(missionId)).willReturn(Optional.of(exploreMission1));
+
+            // when & then
+            assertThatThrownBy(() -> missionQueryService.getValidMission(stampId, missionId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MissionErrorCode.MISSION_ALREADY_COMPLETED.getMessage());
+        }
+
+        @Test
         @DisplayName("특정 스탬프에 속하고 삭제되지 않은 미션이 존재하면, 해당 미션을 반환한다.")
         void shouldReturnValidMission() {
             // given

--- a/src/test/java/com/ject/studytrip/stamp/application/service/StampQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/stamp/application/service/StampQueryServiceTest.java
@@ -85,15 +85,29 @@ class StampQueryServiceTest extends BaseUnitTest {
         void shouldThrowExceptionWhenStampAlreadyDeleted() {
             // given
             courseStamp1.updateDeletedAt();
-            given(stampRepository.findById(any())).willReturn(Optional.ofNullable(courseStamp1));
+            Long tripId = courseTrip.getId();
+            Long stampId = courseStamp1.getId();
+            given(stampRepository.findById(stampId)).willReturn(Optional.ofNullable(courseStamp1));
 
             // when & then
-            assertThatThrownBy(
-                            () ->
-                                    stampQueryService.getValidStamp(
-                                            courseStamp1.getId(), courseStamp1.getId()))
+            assertThatThrownBy(() -> stampQueryService.getValidStamp(tripId, stampId))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(StampErrorCode.STAMP_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("완료된 스탬프일 경우 예외가 발생한다.")
+        void shouldThrowExceptionWhenStampAlreadyCompleted() {
+            // given
+            courseStamp1.updateCompleted();
+            Long tripId = courseTrip.getId();
+            Long stampId = courseStamp1.getId();
+            given(stampRepository.findById(stampId)).willReturn(Optional.ofNullable(courseStamp1));
+
+            // when & then
+            assertThatThrownBy(() -> stampQueryService.getValidStamp(tripId, stampId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(StampErrorCode.STAMP_ALREADY_COMPLETED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/ject/studytrip/trip/application/service/TripQueryServiceTest.java
+++ b/src/test/java/com/ject/studytrip/trip/application/service/TripQueryServiceTest.java
@@ -113,6 +113,20 @@ class TripQueryServiceTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("이미 완료된 여행일 경우 예외가 발생한다")
+        void shouldThrowExceptionWhenTripAlreadyCompleted() {
+            // given
+            trip.updateCompleted();
+            Long tripId = trip.getId();
+            given(tripRepository.findById(tripId)).willReturn(Optional.of(trip));
+
+            // when & then
+            assertThatThrownBy(() -> tripQueryService.getValidTrip(member.getId(), tripId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(TripErrorCode.TRIP_ALREADY_COMPLETED.getMessage());
+        }
+
+        @Test
         @DisplayName("특정 여행 ID로 DB에서 조회한 후 유효한 여행을 반환한다")
         void shouldGetTripByTripIdReturnValidTrip() {
             // given


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ 검증 조회 비즈니스 로직에 완료 여부 검증 정책 추가
- `TripQueryService.getValidTrip()`에 `TripPolicy.validateCompleted()` 추가
- `StampQueryService.getValidStamp()`에 `StampPolicy.validateCompleted()` 추가
- `MissionQueryService.getValidMission()`에 `MissionPolicy.validateCompleted()` 추가

### ✅ 테스트
- `TripQueryServiceTest`에서 `GetValidTrip` 단위 테스트 수정
- `StampQueryServiceTest`에서 `GetValidStamp` 단위 테스트 수정
- `MissionQueryServiceTest`에서 `GetValidMission` 단위 테스트 수정

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #116 

<br/>

## 🔍 참고사항(선택)

- `MemberFacade.confirmImage()`에 멤버 캐시 무효화 로직 추가 -> **MEMBER**
- `StudyLogFacade.confirmImage()`에 학습 로그 캐시 무효화 로직 추가 -> **STUDYLOGS**

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-