### PR TITLE
refactor: 여행 리포트 기능에 Redis 캐싱 적용(#118)

### DIFF
--- a/src/main/java/com/ject/studytrip/global/common/constants/CacheNameConstants.java
+++ b/src/main/java/com/ject/studytrip/global/common/constants/CacheNameConstants.java
@@ -12,4 +12,6 @@ public final class CacheNameConstants {
     public static final String MISSIONS = "missions";
     public static final String DAILY_GOAL = "dailyGoal";
     public static final String STUDY_LOGS = "studyLogs";
+    public static final String TRIP_REPORT = "tripReport";
+    public static final String TRIP_REPORTS = "tripReports";
 }

--- a/src/main/java/com/ject/studytrip/global/common/factory/CacheKeyFactory.java
+++ b/src/main/java/com/ject/studytrip/global/common/factory/CacheKeyFactory.java
@@ -10,7 +10,7 @@ public class CacheKeyFactory {
     }
 
     public static String trips(Long memberId, int page, int size) {
-        return "member:" + memberId + ":page:" + page + ":size:" + size;
+        return "member:" + memberId + ":trips" + ":page:" + page + ":size:" + size;
     }
 
     public static String trip(Long memberId, Long tripId) {
@@ -18,7 +18,7 @@ public class CacheKeyFactory {
     }
 
     public static String stamps(Long memberId, Long tripId) {
-        return "member:" + memberId + ":trip:" + tripId;
+        return "member:" + memberId + ":trip:" + tripId + ":stamps";
     }
 
     public static String stamp(Long memberId, Long tripId, Long stampId) {
@@ -26,7 +26,7 @@ public class CacheKeyFactory {
     }
 
     public static String missions(Long memberId, Long tripId, Long stampId) {
-        return "member:" + memberId + ":trip:" + tripId + ":stamp:" + stampId;
+        return "member:" + memberId + ":trip:" + tripId + ":stamp:" + stampId + ":missions";
     }
 
     public static String dailyGoal(Long memberId, Long tripId, Long dailyGoalId) {
@@ -38,11 +38,27 @@ public class CacheKeyFactory {
                 + memberId
                 + ":trip:"
                 + tripId
+                + ":studyLogs"
                 + ":page:"
                 + page
                 + ":size:"
                 + size
                 + ":order:"
                 + order.toLowerCase();
+    }
+
+    public static String tripReports(Long memberId) {
+        return "member:" + memberId + ":tripReports";
+    }
+
+    public static String tripReport(Long memberId, Long tripReportId, int page, int size) {
+        return "member:"
+                + memberId
+                + ":tripReport:"
+                + tripReportId
+                + ":page:"
+                + page
+                + ":size:"
+                + size;
     }
 }

--- a/src/main/java/com/ject/studytrip/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/ject/studytrip/global/config/RedisCacheConfig.java
@@ -50,9 +50,11 @@ public class RedisCacheConfig {
         configs.put(MEMBER, common.entryTtl(Duration.ofMinutes(10))); // 멤버 상세 조회
         configs.put(DAILY_GOAL, common.entryTtl(Duration.ofMinutes(10))); // 데일리 목표 상세 조회
         configs.put(STUDY_LOGS, common.entryTtl(Duration.ofMinutes(10))); // 학습 로그 목록 조회
+        configs.put(TRIP_REPORTS, common.entryTtl(Duration.ofMinutes(10))); // 여행 리포트 목록 조회
 
         configs.put(TRIP, common.entryTtl(Duration.ofMinutes(5))); // 여행 상세 조회
         configs.put(STAMP, common.entryTtl(Duration.ofMinutes(5))); // 스탬프 상세 조회
+        configs.put(TRIP_REPORT, common.entryTtl(Duration.ofMinutes(5))); // 여행 리포트 상세 조회
 
         configs.put(TRIPS, common.entryTtl(Duration.ofMinutes(3))); // 여행 목록 조회(페이지)
         configs.put(STAMPS, common.entryTtl(Duration.ofMinutes(3))); // 스탬프 목록 조회

--- a/src/main/java/com/ject/studytrip/trip/application/facade/TripReportFacade.java
+++ b/src/main/java/com/ject/studytrip/trip/application/facade/TripReportFacade.java
@@ -1,5 +1,8 @@
 package com.ject.studytrip.trip.application.facade;
 
+import static com.ject.studytrip.global.common.constants.CacheNameConstants.TRIP_REPORT;
+import static com.ject.studytrip.global.common.constants.CacheNameConstants.TRIP_REPORTS;
+
 import com.ject.studytrip.image.application.dto.PresignedImageInfo;
 import com.ject.studytrip.image.application.service.ImageService;
 import com.ject.studytrip.member.application.service.MemberQueryService;
@@ -25,6 +28,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,6 +77,10 @@ public class TripReportFacade {
         return TripRetrospectDetail.from(summary, tripInfo, studyLogDetailSlice);
     }
 
+    @Cacheable(
+            cacheNames = TRIP_REPORTS,
+            key =
+                    "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).tripReports(#memberId)")
     @Transactional(readOnly = true)
     public TripReportsInfo getTripReportsByMember(Long memberId) {
         Member member = memberQueryService.getValidMember(memberId);
@@ -80,6 +90,10 @@ public class TripReportFacade {
         return TripReportsInfo.of(tripReports.stream().map(TripReportInfo::from).toList());
     }
 
+    @Cacheable(
+            cacheNames = TRIP_REPORT,
+            key =
+                    "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).tripReport(#memberId, #tripReportId, #page, #size)")
     @Transactional(readOnly = true)
     public TripReportDetail getTripReport(Long memberId, Long tripReportId, int page, int size) {
         Member member = memberQueryService.getValidMember(memberId);
@@ -95,6 +109,10 @@ public class TripReportFacade {
         return TripReportDetail.from(tripReportInfo, studyLogDetailSlice);
     }
 
+    @CacheEvict(
+            cacheNames = TRIP_REPORTS,
+            key =
+                    "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).tripReports(#memberId)")
     @Transactional
     public TripReportInfo createTripReport(Long memberId, CreateTripReportRequest request) {
         Member member = memberQueryService.getValidMember(memberId);
@@ -105,6 +123,14 @@ public class TripReportFacade {
         return TripReportInfo.from(tripReport);
     }
 
+    @Caching(
+            evict = {
+                @CacheEvict(
+                        cacheNames = TRIP_REPORTS,
+                        key =
+                                "T(com.ject.studytrip.global.common.factory.CacheKeyFactory).tripReports(#memberId)"),
+                @CacheEvict(cacheNames = TRIP_REPORT, allEntries = true)
+            })
     @Transactional
     public void deleteTripReport(Long memberId, Long tripReportId) {
         Member member = memberQueryService.getValidMember(memberId);
@@ -129,6 +155,11 @@ public class TripReportFacade {
                 tripReport.getId(), info.tmpKey(), info.presignedUrl());
     }
 
+    @Caching(
+            evict = {
+                @CacheEvict(cacheNames = TRIP_REPORTS, allEntries = true),
+                @CacheEvict(cacheNames = TRIP_REPORT, allEntries = true)
+            })
     @Transactional
     public void confirmImage(Long tripReportId, ConfirmTripReportImageRequest request) {
         TripReport tripReport = tripReportQueryService.getTripReport(tripReportId);


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항

### ✅ Redis 캐싱 적용
- `CacheNameConstants`, `CacheKeyFactory`에 `TRIP_REPORTS`, `TRIP_REPORT`를 추가하여 **캐시 키 관리 체계화**
- `RedisCacheConfig`에 `TRIP_REPORT`, `TRIP_REPORTS` **TTL** 전략 추가
- `TripReportFacade` 조회 메서드에 `@Cacheable` 및 등록, 삭제, 이미지 검증/확정 메서드에 `@CacheEvict` 적용

### ✅ CacheKeyFactory에 세그먼트 추가
- `trips 캐시 키` 구조에 'trips' 세그먼트 추가하여 의미 명확화
- `stamps 캐시 키` 구조에 'stamps' 세그먼트 추가하여 의미 명확화
- `missions 캐시 키` 구조에 'missions' 세그먼트 추가하여 의미 명확화
- `studyLogs 캐시 키` 구조에 'studyLogs' 세그먼트 추가하여 의미 명확화

<br/>

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 적어주세요. -->

- close #118 

<br/>

## 🔍 참고사항(선택)

-

<br/>

## 📚 기타(선택)
<!-- 스크린샷, 이미지 등 -->

-